### PR TITLE
Fix #9: add http auth to XMLRPC requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ jdk: oraclejdk7
 
 android:
   components:
+    - tools
     - extra-android-m2repository
     - extra-android-support
-    - build-tools-23.0.1
+    - build-tools-23.0.2
     - android-23
 
 env:

--- a/WordPressStores/build.gradle
+++ b/WordPressStores/build.gradle
@@ -15,7 +15,6 @@ apply plugin: 'com.neenbedankt.android-apt'
 
 repositories {
     jcenter()
-
 }
 
 android {

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/module/ReleaseNetworkModule.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/module/ReleaseNetworkModule.java
@@ -8,6 +8,7 @@ import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.OkUrlFactory;
 
 import org.wordpress.android.stores.Dispatcher;
+import org.wordpress.android.stores.network.HTTPAuthManager;
 import org.wordpress.android.stores.network.OkHttpStack;
 import org.wordpress.android.stores.network.UserAgent;
 import org.wordpress.android.stores.network.rest.wpcom.account.AccountRestClient;
@@ -65,8 +66,8 @@ public class ReleaseNetworkModule {
     @Singleton
     @Provides
     public SiteXMLRPCClient provideSiteXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, AccessToken token,
-                                                    UserAgent userAgent) {
-        return new SiteXMLRPCClient(dispatcher, requestQueue, token, userAgent);
+                                                    UserAgent userAgent, HTTPAuthManager httpAuthManager) {
+        return new SiteXMLRPCClient(dispatcher, requestQueue, token, userAgent, httpAuthManager);
     }
 
     @Singleton
@@ -80,5 +81,11 @@ public class ReleaseNetworkModule {
     @Provides
     public AccessToken provideAccountToken(Context appContext) {
         return new AccessToken(appContext);
+    }
+
+    @Singleton
+    @Provides
+    public HTTPAuthManager provideHTTPAuthManager(Context appContext) {
+        return new HTTPAuthManager(appContext);
     }
 }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/module/ReleaseNetworkModule.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/module/ReleaseNetworkModule.java
@@ -85,7 +85,7 @@ public class ReleaseNetworkModule {
 
     @Singleton
     @Provides
-    public HTTPAuthManager provideHTTPAuthManager(Context appContext) {
-        return new HTTPAuthManager(appContext);
+    public HTTPAuthManager provideHTTPAuthManager() {
+        return new HTTPAuthManager();
     }
 }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/AuthError.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/AuthError.java
@@ -7,4 +7,5 @@ public enum AuthError implements Payload {
     NOT_AUTHENTICATED,
     INCORRECT_USERNAME_OR_PASSWORD,
     UNAUTHORIZED,
+    HTTP_AUTH_ERROR,
 }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/BaseRequest.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/BaseRequest.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.stores.network;
 
+import android.util.Base64;
+
 import com.android.volley.Response.ErrorListener;
 
 import java.util.HashMap;
@@ -25,13 +27,14 @@ public abstract class BaseRequest<T> extends com.android.volley.Request<T> {
         return mHeaders;
     }
 
-    public void setHTTPAuthHeader(HTTPAuthManager httpAuthManager) {
-        if (httpAuthManager.match(getUrl())) {
-            // FIXME:
-            // Add Auth headers
+    public void setHTTPAuthHeaderOnMatchingURL(HTTPAuthManager httpAuthManager) {
+        HTTPAuthModel httpAuthModel = httpAuthManager.getHTTPAuthModel(getUrl());
+        if (httpAuthModel != null) {
+            String creds = String.format("%s:%s", httpAuthModel.getUsername(), httpAuthModel.getPassword());
+            String auth = "Basic " + Base64.encodeToString(creds.getBytes(), Base64.NO_WRAP);
+            mHeaders.put("Authorization", auth);
         }
     }
-
 
     public void setOnAuthFailedListener(OnAuthFailedListener onAuthFailedListener) {
         mOnAuthFailedListener = onAuthFailedListener;

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/BaseRequest.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/BaseRequest.java
@@ -25,6 +25,14 @@ public abstract class BaseRequest<T> extends com.android.volley.Request<T> {
         return mHeaders;
     }
 
+    public void setHTTPAuthHeader(HTTPAuthManager httpAuthManager) {
+        if (httpAuthManager.match(getUrl())) {
+            // FIXME:
+            // Add Auth headers
+        }
+    }
+
+
     public void setOnAuthFailedListener(OnAuthFailedListener onAuthFailedListener) {
         mOnAuthFailedListener = onAuthFailedListener;
     }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/HTTPAuthManager.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/HTTPAuthManager.java
@@ -1,0 +1,16 @@
+package org.wordpress.android.stores.network;
+
+import android.content.Context;
+
+public class HTTPAuthManager {
+    private Context mContext;
+
+    public HTTPAuthManager(Context appContext) {
+        mContext = appContext;
+    }
+
+    public boolean match(String url) {
+        // FIXME:
+        return true;
+    }
+}

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/HTTPAuthManager.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/HTTPAuthManager.java
@@ -1,16 +1,53 @@
 package org.wordpress.android.stores.network;
 
-import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.wellsql.generated.HTTPAuthModelTable;
+import com.yarolegovich.wellsql.WellSql;
+
+import org.wordpress.android.stores.persistence.HTTPAuthSqlUtils;
+
+import java.net.URI;
+import java.util.List;
 
 public class HTTPAuthManager {
-    private Context mContext;
+    public HTTPAuthManager() {}
 
-    public HTTPAuthManager(Context appContext) {
-        mContext = appContext;
+    private String normalizeURL(String url) {
+        try {
+            URI uri = URI.create(url);
+            return uri.normalize().toString();
+        } catch (IllegalArgumentException e) {
+            return url;
+        }
     }
 
-    public boolean match(String url) {
-        // FIXME:
-        return true;
+    /**
+     * Get an HTTPAuthModel containing username and password for the url parameter
+     * TODO: Use an in memory model (or caching) - because this SQL query is executed every time a request is sent
+     *
+     * @param url to test
+     * @return null if url is not matching any known HTTP auth credentials
+     */
+    public @Nullable HTTPAuthModel getHTTPAuthModel(String url) {
+        List<HTTPAuthModel> authModels = WellSql.selectUnique(HTTPAuthModel.class).where()
+                .equals(HTTPAuthModelTable.ROOT_URL, normalizeURL(url))
+                .endWhere().getAsModel();
+        if (authModels.isEmpty()) {
+            return null;
+        }
+        return authModels.get(0);
+    }
+
+    public void addHTTPAuthCredentials(@NonNull String username, @NonNull String password,
+                                       @NonNull String url, @Nullable String realm) {
+        HTTPAuthModel httpAuthModel = new HTTPAuthModel();
+        httpAuthModel.setUsername(username);
+        httpAuthModel.setPassword(password);
+        httpAuthModel.setRootUrl(normalizeURL(url));
+        httpAuthModel.setRealm(realm);
+        // Replace old username / password / realm - URL used as key
+        HTTPAuthSqlUtils.insertOrUpdateModel(httpAuthModel);
     }
 }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/HTTPAuthModel.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/HTTPAuthModel.java
@@ -1,0 +1,63 @@
+package org.wordpress.android.stores.network;
+
+import com.yarolegovich.wellsql.core.Identifiable;
+import com.yarolegovich.wellsql.core.annotation.Column;
+import com.yarolegovich.wellsql.core.annotation.PrimaryKey;
+import com.yarolegovich.wellsql.core.annotation.RawConstraints;
+import com.yarolegovich.wellsql.core.annotation.Table;
+
+@Table
+@RawConstraints({"UNIQUE (ROOT_URL)"})
+public class HTTPAuthModel implements Identifiable {
+    @PrimaryKey
+    @Column private int mId;
+    @Column private String mRootUrl;
+    @Column private String mRealm;
+    @Column private String mUsername;
+    @Column private String mPassword;
+
+    @Override
+    public int getId() {
+        return mId;
+    }
+
+    @Override
+    public void setId(int id) {
+        mId = id;
+    }
+
+    public HTTPAuthModel() {
+    }
+
+    public String getRealm() {
+        return mRealm;
+    }
+
+    public void setRealm(String realm) {
+        mRealm = realm;
+    }
+
+    public String getUsername() {
+        return mUsername;
+    }
+
+    public void setUsername(String username) {
+        mUsername = username;
+    }
+
+    public String getPassword() {
+        return mPassword;
+    }
+
+    public void setPassword(String password) {
+        mPassword = password;
+    }
+
+    public String getRootUrl() {
+        return mRootUrl;
+    }
+
+    public void setRootUrl(String rootUrl) {
+        mRootUrl = rootUrl;
+    }
+}

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/xmlrpc/BaseXMLRPCClient.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/xmlrpc/BaseXMLRPCClient.java
@@ -8,6 +8,7 @@ import org.wordpress.android.stores.action.AuthenticationAction;
 import org.wordpress.android.stores.model.SiteModel;
 import org.wordpress.android.stores.network.AuthError;
 import org.wordpress.android.stores.network.BaseRequest.OnAuthFailedListener;
+import org.wordpress.android.stores.network.HTTPAuthManager;
 import org.wordpress.android.stores.network.UserAgent;
 import org.wordpress.android.stores.network.rest.wpcom.auth.AccessToken;
 
@@ -18,13 +19,15 @@ public class BaseXMLRPCClient {
     protected final Dispatcher mDispatcher;
     private UserAgent mUserAgent;
     protected OnAuthFailedListener mOnAuthFailedListener;
+    private HTTPAuthManager mHTTPAuthManager;
 
     public BaseXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, AccessToken accessToken,
-                            UserAgent userAgent) {
+                            UserAgent userAgent, HTTPAuthManager httpAuthManager) {
         mRequestQueue = requestQueue;
         mDispatcher = dispatcher;
         mAccessToken = accessToken;
         mUserAgent = userAgent;
+        mHTTPAuthManager = httpAuthManager;
         mOnAuthFailedListener = new OnAuthFailedListener() {
             @Override
             public void onAuthFailed(AuthError authError) {
@@ -40,6 +43,7 @@ public class BaseXMLRPCClient {
     private XMLRPCRequest setRequestAuthParams(XMLRPCRequest request) {
         request.setOnAuthFailedListener(mOnAuthFailedListener);
         request.setUserAgent(mUserAgent.getUserAgent());
+        request.setHTTPAuthHeader(mHTTPAuthManager);
         return request;
     }
 }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/xmlrpc/BaseXMLRPCClient.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/xmlrpc/BaseXMLRPCClient.java
@@ -43,7 +43,7 @@ public class BaseXMLRPCClient {
     private XMLRPCRequest setRequestAuthParams(XMLRPCRequest request) {
         request.setOnAuthFailedListener(mOnAuthFailedListener);
         request.setUserAgent(mUserAgent.getUserAgent());
-        request.setHTTPAuthHeader(mHTTPAuthManager);
+        request.setHTTPAuthHeaderOnMatchingURL(mHTTPAuthManager);
         return request;
     }
 }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/xmlrpc/XMLRPCRequest.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/xmlrpc/XMLRPCRequest.java
@@ -107,5 +107,9 @@ public class XMLRPCRequest extends BaseRequest<Object> {
                 return;
             }
         }
+        if (error instanceof AuthFailureError) {
+            mOnAuthFailedListener.onAuthFailed(AuthError.HTTP_AUTH_ERROR);
+            return;
+        }
     }
 }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -9,6 +9,7 @@ import org.wordpress.android.stores.Dispatcher;
 import org.wordpress.android.stores.action.SiteAction;
 import org.wordpress.android.stores.model.SiteModel;
 import org.wordpress.android.stores.model.SitesModel;
+import org.wordpress.android.stores.network.HTTPAuthManager;
 import org.wordpress.android.stores.network.UserAgent;
 import org.wordpress.android.stores.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.stores.network.xmlrpc.BaseXMLRPCClient;
@@ -24,8 +25,8 @@ import java.util.Map;
 
 public class SiteXMLRPCClient extends BaseXMLRPCClient {
     public SiteXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, AccessToken accessToken,
-                            UserAgent userAgent) {
-        super(dispatcher, requestQueue, accessToken, userAgent);
+                            UserAgent userAgent, HTTPAuthManager httpAuthManager) {
+        super(dispatcher, requestQueue, accessToken, userAgent, httpAuthManager);
     }
 
     public void pullSites(final String xmlrpcUrl, final String username, final String password) {

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/persistence/HTTPAuthSqlUtils.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/persistence/HTTPAuthSqlUtils.java
@@ -1,0 +1,37 @@
+package org.wordpress.android.stores.persistence;
+
+import android.content.ContentValues;
+
+import com.wellsql.generated.HTTPAuthModelTable;
+import com.yarolegovich.wellsql.WellSql;
+import com.yarolegovich.wellsql.mapper.InsertMapper;
+
+import org.wordpress.android.stores.network.HTTPAuthModel;
+
+import java.util.List;
+
+public class HTTPAuthSqlUtils {
+    public static void insertOrUpdateModel(HTTPAuthModel model) {
+        List<HTTPAuthModel> modelResult = WellSql.select(HTTPAuthModel.class)
+                .where().equals(HTTPAuthModelTable.ROOT_URL, model.getRootUrl()).endWhere()
+                .getAsModel();
+        if (modelResult.isEmpty()) {
+            // insert
+            WellSql.insert(model).asSingleTransaction(true).execute();
+        } else {
+            // update
+            int oldId = modelResult.get(0).getId();
+            WellSql.update(HTTPAuthModel.class).whereId(oldId)
+                   .put(model, new InsertMapper<HTTPAuthModel>() {
+                       @Override
+                       public ContentValues toCv(HTTPAuthModel item) {
+                           ContentValues cv = new ContentValues();
+                           cv.put(HTTPAuthModelTable.USERNAME, item.getUsername());
+                           cv.put(HTTPAuthModelTable.PASSWORD, item.getPassword());
+                           cv.put(HTTPAuthModelTable.REALM, item.getRealm());
+                           return cv;
+                       }
+                   }).execute();
+        }
+    }
+}

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/persistence/WellSqlConfig.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/persistence/WellSqlConfig.java
@@ -11,6 +11,7 @@ import com.yarolegovich.wellsql.mapper.SQLiteMapper;
 
 import org.wordpress.android.stores.model.AccountModel;
 import org.wordpress.android.stores.model.SiteModel;
+import org.wordpress.android.stores.network.HTTPAuthModel;
 
 import java.util.Map;
 
@@ -21,7 +22,8 @@ public class WellSqlConfig extends DefaultWellConfig {
 
     private static Class[] TABLES = {
             AccountModel.class,
-            SiteModel.class
+            SiteModel.class,
+            HTTPAuthModel.class
     };
 
     @Override

--- a/example/src/androidTest/java/org/wordpress/android/stores/TestUtils.java
+++ b/example/src/androidTest/java/org/wordpress/android/stores/TestUtils.java
@@ -4,7 +4,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
 public class TestUtils {
-    public static int DEFAULT_TIMEOUT = 60000;
+    public static int DEFAULT_TIMEOUT_MS = 30000;
 
     public static void waitFor(long milliseconds) {
         try {
@@ -15,7 +15,7 @@ public class TestUtils {
     }
 
     public static void waitForNetworkCall() {
-        waitFor(DEFAULT_TIMEOUT);
+        waitFor(DEFAULT_TIMEOUT_MS);
     }
 }
 

--- a/example/src/androidTest/java/org/wordpress/android/stores/module/MockedNetworkModule.java
+++ b/example/src/androidTest/java/org/wordpress/android/stores/module/MockedNetworkModule.java
@@ -10,6 +10,7 @@ import com.squareup.okhttp.OkUrlFactory;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.wordpress.android.stores.Dispatcher;
+import org.wordpress.android.stores.network.HTTPAuthManager;
 import org.wordpress.android.stores.network.OkHttpStack;
 import org.wordpress.android.stores.network.UserAgent;
 import org.wordpress.android.stores.network.rest.wpcom.account.AccountRestClient;
@@ -104,8 +105,8 @@ public class MockedNetworkModule {
     @Singleton
     @Provides
     public SiteXMLRPCClient provideSiteXMLRPCClient(Dispatcher dispatcher, RequestQueue requestQueue, AccessToken token,
-                                                    UserAgent userAgent) {
-        return new SiteXMLRPCClient(dispatcher, requestQueue, token, userAgent);
+                                                    UserAgent userAgent, HTTPAuthManager httpAuthManager) {
+        return new SiteXMLRPCClient(dispatcher, requestQueue, token, userAgent, httpAuthManager);
     }
 
     @Singleton
@@ -119,5 +120,11 @@ public class MockedNetworkModule {
     @Provides
     public AccessToken provideAccountToken(Context appContext) {
         return new AccessToken(appContext);
+    }
+
+    @Singleton
+    @Provides
+    public HTTPAuthManager provideHTTPAuthManager() {
+        return new HTTPAuthManager();
     }
 }

--- a/example/src/androidTest/java/org/wordpress/android/stores/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/stores/release/ReleaseStack_AccountTest.java
@@ -46,13 +46,13 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
         mDispatcher.dispatch(AuthenticationAction.AUTHENTICATE, payload);
         mCountDownLatch = new CountDownLatch(1);
         // Wait for a network response / onChanged event
-        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS));
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
         // Get user infos
         mDispatcher.dispatch(AccountAction.FETCH);
         mCountDownLatch = new CountDownLatch(1);
         // Wait for a network response / onChanged event
-        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS));
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     @Subscribe

--- a/example/src/androidTest/java/org/wordpress/android/stores/release/ReleaseStack_SiteTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/stores/release/ReleaseStack_SiteTest.java
@@ -23,8 +23,17 @@ import javax.inject.Inject;
 public class ReleaseStack_SiteTest extends ReleaseStack_Base {
     @Inject Dispatcher mDispatcher;
     @Inject SiteStore mSiteStore;
+    @Inject AccountStore mAccountStore;
+    @Inject HTTPAuthManager mHTTPAuthManager;
 
     CountDownLatch mCountDownLatch;
+
+    enum TEST_EVENTS {
+        NONE,
+        HTTP_AUTH_ERROR,
+        SITE_CHANGED
+    }
+    private TEST_EVENTS mExpectedEvent;
 
     @Override
     protected void setUp() throws Exception {
@@ -32,7 +41,10 @@ public class ReleaseStack_SiteTest extends ReleaseStack_Base {
         mReleaseStackAppComponent.inject(this);
         // Register
         mDispatcher.register(mSiteStore);
+        mDispatcher.register(mAccountStore);
         mDispatcher.register(this);
+        // Reset expected test event
+        mExpectedEvent = TEST_EVENTS.NONE;
     }
 
     public void testSelfHostedSimpleFetchSites() throws InterruptedException {
@@ -40,10 +52,11 @@ public class ReleaseStack_SiteTest extends ReleaseStack_Base {
         payload.username = BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE;
         payload.password = BuildConfig.TEST_WPORG_PASSWORD_SH_SIMPLE;
         payload.xmlrpcEndpoint = BuildConfig.TEST_WPORG_URL_SH_SIMPLE;
-        mDispatcher.dispatch(SiteAction.FETCH_SITES_XMLRPC, payload);
+        mExpectedEvent = TEST_EVENTS.SITE_CHANGED;
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(SiteAction.FETCH_SITES_XMLRPC, payload);
         // Wait for a network response / onChanged event
-        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS));
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testSelfHostedSimpleContributorFetchSites() throws InterruptedException {
@@ -51,10 +64,11 @@ public class ReleaseStack_SiteTest extends ReleaseStack_Base {
         payload.username = BuildConfig.TEST_WPORG_USERNAME_SH_SIMPLE_CONTRIB;
         payload.password = BuildConfig.TEST_WPORG_PASSWORD_SH_SIMPLE_CONTRIB;
         payload.xmlrpcEndpoint = BuildConfig.TEST_WPORG_URL_SH_SIMPLE_CONTRIB;
-        mDispatcher.dispatch(SiteAction.FETCH_SITES_XMLRPC, payload);
+        mExpectedEvent = TEST_EVENTS.SITE_CHANGED;
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(SiteAction.FETCH_SITES_XMLRPC, payload);
         // Wait for a network response / onChanged event
-        assertEquals(true, mCountDownLatch.await(10000, TimeUnit.MILLISECONDS));
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testSelfHostedMutliSiteFetchSites() throws InterruptedException {
@@ -62,10 +76,11 @@ public class ReleaseStack_SiteTest extends ReleaseStack_Base {
         payload.username = BuildConfig.TEST_WPORG_USERNAME_SH_MULTISITE;
         payload.password = BuildConfig.TEST_WPORG_PASSWORD_SH_MULTISITE;
         payload.xmlrpcEndpoint = BuildConfig.TEST_WPORG_URL_SH_MULTISITE;
-        mDispatcher.dispatch(SiteAction.FETCH_SITES_XMLRPC, payload);
+        mExpectedEvent = TEST_EVENTS.SITE_CHANGED;
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(SiteAction.FETCH_SITES_XMLRPC, payload);
         // Wait for a network response / onChanged event
-        assertEquals(true, mCountDownLatch.await(10000, TimeUnit.MILLISECONDS));
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testSelfHostedSimpleHTTPSFetchSites() throws InterruptedException {
@@ -73,10 +88,11 @@ public class ReleaseStack_SiteTest extends ReleaseStack_Base {
         payload.username = BuildConfig.TEST_WPORG_USERNAME_SH_VALID_SSL;
         payload.password = BuildConfig.TEST_WPORG_PASSWORD_SH_VALID_SSL;
         payload.xmlrpcEndpoint = BuildConfig.TEST_WPORG_URL_SH_VALID_SSL;
-        mDispatcher.dispatch(SiteAction.FETCH_SITES_XMLRPC, payload);
+        mExpectedEvent = TEST_EVENTS.SITE_CHANGED;
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(SiteAction.FETCH_SITES_XMLRPC, payload);
         // Wait for a network response / onChanged event
-        assertEquals(true, mCountDownLatch.await(10000, TimeUnit.MILLISECONDS));
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testSelfHostedSelfSignedSSLFetchSites() throws InterruptedException {
@@ -84,12 +100,13 @@ public class ReleaseStack_SiteTest extends ReleaseStack_Base {
         payload.username = BuildConfig.TEST_WPORG_USERNAME_SH_SELFSIGNED_SSL;
         payload.password = BuildConfig.TEST_WPORG_PASSWORD_SH_SELFSIGNED_SSL;
         payload.xmlrpcEndpoint = BuildConfig.TEST_WPORG_URL_SH_SELFSIGNED_SSL;
-        mDispatcher.dispatch(SiteAction.FETCH_SITES_XMLRPC, payload);
+        mExpectedEvent = TEST_EVENTS.SITE_CHANGED;
         mCountDownLatch = new CountDownLatch(1);
+        mDispatcher.dispatch(SiteAction.FETCH_SITES_XMLRPC, payload);
         // TODO: should get a SSL Warning event
 
         // Wait for a network response / onChanged event
-        assertEquals(true, mCountDownLatch.await(10000, TimeUnit.MILLISECONDS));
+        assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }
 
     public void testSelfHostedHTTPAuthFetchSites() throws InterruptedException {

--- a/example/src/main/java/org/wordpress/android/stores/example/MainExampleActivity.java
+++ b/example/src/main/java/org/wordpress/android/stores/example/MainExampleActivity.java
@@ -19,6 +19,7 @@ import org.wordpress.android.stores.action.SiteAction;
 import org.wordpress.android.stores.example.SignInDialog.Listener;
 import org.wordpress.android.stores.model.SiteModel;
 import org.wordpress.android.stores.network.AuthError;
+import org.wordpress.android.stores.network.HTTPAuthManager;
 import org.wordpress.android.stores.store.AccountStore;
 import org.wordpress.android.stores.store.AccountStore.AuthenticatePayload;
 import org.wordpress.android.stores.store.AccountStore.OnAccountChanged;
@@ -37,12 +38,15 @@ public class MainExampleActivity extends AppCompatActivity {
     @Inject SiteStore mSiteStore;
     @Inject AccountStore mAccountStore;
     @Inject Dispatcher mDispatcher;
+    @Inject HTTPAuthManager mHTTPAuthManager;
 
     private TextView mLogView;
     private Button mAccountInfos;
     private Button mListSites;
     private Button mLogSites;
     private Button mUpdateFirstSite;
+    // Would be great to not have to keep this state, but it makes HTTPAuth and self signed SSL management easier
+    private RefreshSitesXMLRPCPayload mSelfhostedPayload;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -119,7 +123,7 @@ public class MainExampleActivity extends AppCompatActivity {
             prependToLog("Authentication error: " + event.authError);
             if (event.authError == AuthError.HTTP_AUTH_ERROR) {
                 // Show a Dialog prompting for http username and password
-                showHttpAuthDialog();
+                showHTTPAuthDialog(mSelfhostedPayload.xmlrpcEndpoint);
             }
         }
     }
@@ -149,16 +153,22 @@ public class MainExampleActivity extends AppCompatActivity {
             public void onClick(String username, String password, String url) {
                 signInAction(username, password, url);
             }
-        });
+        }, true);
         newFragment.show(ft, "dialog");
     }
 
-    private void showHttpAuthDialog() {
+    private void showHTTPAuthDialog(final String url) {
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
         DialogFragment newFragment = SignInDialog.newInstance(new Listener() {
             @Override
-            public void onClick(String username, String password, String url) {
-                signInAction(username, password, url);
+            public void onClick(String username, String password, String dummy) {
+                // Add credentials
+                mHTTPAuthManager.addHTTPAuthCredentials(username, password, url, null);
+                // Retry login action
+                if (mSelfhostedPayload != null) {
+                    selfHostedFetchSites(mSelfhostedPayload.username, mSelfhostedPayload.password,
+                            mSelfhostedPayload.xmlrpcEndpoint);
+                }
             }
         }, false);
         newFragment.show(ft, "dialog");
@@ -203,6 +213,7 @@ public class MainExampleActivity extends AppCompatActivity {
         payload.username = username;
         payload.password = password;
         payload.xmlrpcEndpoint = xmlrpcEndpoint;
+        mSelfhostedPayload = payload;
         // Self Hosted don't have any "Authentication" request, try to list sites with user/password
         mDispatcher.dispatch(SiteAction.FETCH_SITES_XMLRPC, payload);
     }

--- a/example/src/main/java/org/wordpress/android/stores/example/MainExampleActivity.java
+++ b/example/src/main/java/org/wordpress/android/stores/example/MainExampleActivity.java
@@ -18,6 +18,7 @@ import org.wordpress.android.stores.action.AuthenticationAction;
 import org.wordpress.android.stores.action.SiteAction;
 import org.wordpress.android.stores.example.SignInDialog.Listener;
 import org.wordpress.android.stores.model.SiteModel;
+import org.wordpress.android.stores.network.AuthError;
 import org.wordpress.android.stores.store.AccountStore;
 import org.wordpress.android.stores.store.AccountStore.AuthenticatePayload;
 import org.wordpress.android.stores.store.AccountStore.OnAccountChanged;
@@ -116,6 +117,10 @@ public class MainExampleActivity extends AppCompatActivity {
         mAccountInfos.setEnabled(mAccountStore.hasAccessToken());
         if (event.isError) {
             prependToLog("Authentication error: " + event.authError);
+            if (event.authError == AuthError.HTTP_AUTH_ERROR) {
+                // Show a Dialog prompting for http username and password
+                showHttpAuthDialog();
+            }
         }
     }
 
@@ -145,6 +150,17 @@ public class MainExampleActivity extends AppCompatActivity {
                 signInAction(username, password, url);
             }
         });
+        newFragment.show(ft, "dialog");
+    }
+
+    private void showHttpAuthDialog() {
+        FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+        DialogFragment newFragment = SignInDialog.newInstance(new Listener() {
+            @Override
+            public void onClick(String username, String password, String url) {
+                signInAction(username, password, url);
+            }
+        }, false);
         newFragment.show(ft, "dialog");
     }
 

--- a/example/src/main/java/org/wordpress/android/stores/example/SignInDialog.java
+++ b/example/src/main/java/org/wordpress/android/stores/example/SignInDialog.java
@@ -20,15 +20,25 @@ public class SignInDialog extends DialogFragment {
     private EditText mUsernameView;
     private EditText mPasswordView;
     private EditText mUrlView;
+    private boolean mUrlEnabled;
 
     public void setListener(Listener onClickListener) {
         mListener = onClickListener;
     }
 
-    public static SignInDialog newInstance(Listener onClickListener) {
+    public static SignInDialog newInstance(Listener onClickListener, boolean enableUrl) {
         SignInDialog fragment = new SignInDialog();
         fragment.setListener(onClickListener);
+        fragment.setUrlEnabled(enableUrl);
         return fragment;
+    }
+
+    public boolean isUrlEnabled() {
+        return mUrlEnabled;
+    }
+
+    public void setUrlEnabled(boolean urlEnabled) {
+        mUrlEnabled = urlEnabled;
     }
 
     @Override
@@ -40,6 +50,9 @@ public class SignInDialog extends DialogFragment {
         mUsernameView = (EditText) view.findViewById(R.id.username);
         mPasswordView = (EditText) view.findViewById(R.id.password);
         mUrlView = (EditText) view.findViewById(R.id.url);
+        if (!mUrlEnabled) {
+            mUrlView.setVisibility(View.GONE);
+        }
         builder.setView(view)
                 .setPositiveButton(android.R.string.ok, new OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {

--- a/example/src/main/res/layout/signin_dialog.xml
+++ b/example/src/main/res/layout/signin_dialog.xml
@@ -12,7 +12,7 @@
         android:hint="Username" />
     <EditText
         android:id="@+id/password"
-        android:inputType="textPassword"
+        android:inputType="text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="4dp"


### PR DESCRIPTION
Fix #9: add http auth to XMLRPC requests + updated tests.

(It can be extended to WP-API REST super easily).