### PR TITLE
Fix #16: Move XML-RPC and REST API endpoints to enums

### DIFF
--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/BaseWPComRestClient.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/BaseWPComRestClient.java
@@ -16,12 +16,6 @@ public class BaseWPComRestClient {
     protected final Dispatcher mDispatcher;
     private UserAgent mUserAgent;
 
-    private static final String WPCOM_REST_PREFIX = "https://public-api.wordpress.com/rest";
-    protected static final String WPCOM_PREFIX_V1 = WPCOM_REST_PREFIX + "/v1";
-    protected static final String WPCOM_PREFIX_V1_1 = WPCOM_REST_PREFIX + "/v1.1";
-    protected static final String WPCOM_PREFIX_V1_2 = WPCOM_REST_PREFIX + "/v1.2";
-    protected static final String WPCOM_PREFIX_V1_3 = WPCOM_REST_PREFIX + "/v1.3";
-
     protected OnAuthFailedListener mOnAuthFailedListener;
 
     public BaseWPComRestClient(Dispatcher dispatcher, RequestQueue requestQueue, AccessToken accessToken,

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/WPCOMREST.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/WPCOMREST.java
@@ -1,0 +1,18 @@
+package org.wordpress.android.stores.network.rest.wpcom;
+
+public enum WPCOMREST {
+    ME("/me/"),
+    ME_SITES("/me/sites/"),
+    SITES("/sites/");
+
+    private final String mEndpoint;
+
+    WPCOMREST(String endpoint) {
+        mEndpoint = endpoint;
+    }
+
+    @Override
+    public String toString() {
+        return mEndpoint;
+    }
+}

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/WPCOMREST.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/WPCOMREST.java
@@ -1,14 +1,15 @@
 package org.wordpress.android.stores.network.rest.wpcom;
 
-import static org.wordpress.android.stores.network.rest.wpcom.BaseWPComRestClient.WPCOM_PREFIX_V1;
-import static org.wordpress.android.stores.network.rest.wpcom.BaseWPComRestClient.WPCOM_PREFIX_V1_1;
-import static org.wordpress.android.stores.network.rest.wpcom.BaseWPComRestClient.WPCOM_PREFIX_V1_2;
-import static org.wordpress.android.stores.network.rest.wpcom.BaseWPComRestClient.WPCOM_PREFIX_V1_3;
-
 public enum WPCOMREST {
     ME("/me/"),
     ME_SITES("/me/sites/"),
     SITES("/sites/");
+
+    private static final String WPCOM_REST_PREFIX = "https://public-api.wordpress.com/rest";
+    private static final String WPCOM_PREFIX_V1 = WPCOM_REST_PREFIX + "/v1";
+    private static final String WPCOM_PREFIX_V1_1 = WPCOM_REST_PREFIX + "/v1.1";
+    private static final String WPCOM_PREFIX_V1_2 = WPCOM_REST_PREFIX + "/v1.2";
+    private static final String WPCOM_PREFIX_V1_3 = WPCOM_REST_PREFIX + "/v1.3";
 
     private final String mEndpoint;
 

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/WPCOMREST.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/WPCOMREST.java
@@ -1,5 +1,10 @@
 package org.wordpress.android.stores.network.rest.wpcom;
 
+import static org.wordpress.android.stores.network.rest.wpcom.BaseWPComRestClient.WPCOM_PREFIX_V1;
+import static org.wordpress.android.stores.network.rest.wpcom.BaseWPComRestClient.WPCOM_PREFIX_V1_1;
+import static org.wordpress.android.stores.network.rest.wpcom.BaseWPComRestClient.WPCOM_PREFIX_V1_2;
+import static org.wordpress.android.stores.network.rest.wpcom.BaseWPComRestClient.WPCOM_PREFIX_V1_3;
+
 public enum WPCOMREST {
     ME("/me/"),
     ME_SITES("/me/sites/"),
@@ -14,5 +19,21 @@ public enum WPCOMREST {
     @Override
     public String toString() {
         return mEndpoint;
+    }
+
+    public String getUrlV1() {
+        return WPCOM_PREFIX_V1 + mEndpoint;
+    }
+
+    public String getUrlV1_1() {
+        return WPCOM_PREFIX_V1_1 + mEndpoint;
+    }
+
+    public String getUrlV1_2() {
+        return WPCOM_PREFIX_V1_2 + mEndpoint;
+    }
+
+    public String getUrlV1_3() {
+        return WPCOM_PREFIX_V1_3 + mEndpoint;
     }
 }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/account/AccountRestClient.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/account/AccountRestClient.java
@@ -11,6 +11,7 @@ import org.wordpress.android.stores.action.AccountAction;
 import org.wordpress.android.stores.model.AccountModel;
 import org.wordpress.android.stores.network.UserAgent;
 import org.wordpress.android.stores.network.rest.wpcom.BaseWPComRestClient;
+import org.wordpress.android.stores.network.rest.wpcom.WPCOMREST;
 import org.wordpress.android.stores.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.stores.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.util.AppLog;
@@ -28,7 +29,7 @@ public class AccountRestClient extends BaseWPComRestClient {
     }
 
     public void getMe() {
-        final String url = WPCOM_PREFIX_V1_1 + "/me/";
+        final String url = WPCOM_PREFIX_V1_1 + WPCOMREST.ME;
         final WPComGsonRequest<AccountResponse> request = new WPComGsonRequest<>(Method.GET,
                 url, null, AccountResponse.class,
                 new Listener<AccountResponse>() {

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/account/AccountRestClient.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/account/AccountRestClient.java
@@ -29,7 +29,7 @@ public class AccountRestClient extends BaseWPComRestClient {
     }
 
     public void getMe() {
-        final String url = WPCOM_PREFIX_V1_1 + WPCOMREST.ME;
+        final String url = WPCOMREST.ME.getUrlV1_1();
         final WPComGsonRequest<AccountResponse> request = new WPComGsonRequest<>(Method.GET,
                 url, null, AccountResponse.class,
                 new Listener<AccountResponse>() {

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/site/SiteRestClient.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/site/SiteRestClient.java
@@ -31,7 +31,7 @@ public class SiteRestClient extends BaseWPComRestClient {
     }
 
     public void pullSites() {
-        String url = WPCOM_PREFIX_V1_1 + WPCOMREST.ME_SITES;
+        String url = WPCOMREST.ME_SITES.getUrlV1_1();
         final WPComGsonRequest<SitesResponse> request = new WPComGsonRequest<>(Method.GET,
                 url, null, SitesResponse.class,
                 new Listener<SitesResponse>() {
@@ -56,7 +56,7 @@ public class SiteRestClient extends BaseWPComRestClient {
     }
 
     public void pullSite(final SiteModel site) {
-        String url = WPCOM_PREFIX_V1_1 + WPCOMREST.SITES + site.getSiteId();
+        String url = WPCOMREST.SITES.getUrlV1_1() + site.getSiteId();
         final WPComGsonRequest<SiteWPComRestResponse> request = new WPComGsonRequest<>(Method.GET,
                 url, null, SiteWPComRestResponse.class,
                 new Listener<SiteWPComRestResponse>() {

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/site/SiteRestClient.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/site/SiteRestClient.java
@@ -12,6 +12,7 @@ import org.wordpress.android.stores.model.SiteModel;
 import org.wordpress.android.stores.model.SitesModel;
 import org.wordpress.android.stores.network.UserAgent;
 import org.wordpress.android.stores.network.rest.wpcom.BaseWPComRestClient;
+import org.wordpress.android.stores.network.rest.wpcom.WPCOMREST;
 import org.wordpress.android.stores.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.stores.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.stores.network.rest.wpcom.site.SiteWPComRestResponse.SitesResponse;
@@ -30,7 +31,7 @@ public class SiteRestClient extends BaseWPComRestClient {
     }
 
     public void pullSites() {
-        String url = WPCOM_PREFIX_V1_1 + "/me/sites/";
+        String url = WPCOM_PREFIX_V1_1 + WPCOMREST.ME_SITES;
         final WPComGsonRequest<SitesResponse> request = new WPComGsonRequest<>(Method.GET,
                 url, null, SitesResponse.class,
                 new Listener<SitesResponse>() {
@@ -55,7 +56,7 @@ public class SiteRestClient extends BaseWPComRestClient {
     }
 
     public void pullSite(final SiteModel site) {
-        String url = WPCOM_PREFIX_V1_1 + "/sites/" + site.getSiteId();
+        String url = WPCOM_PREFIX_V1_1 + WPCOMREST.SITES + site.getSiteId();
         final WPComGsonRequest<SiteWPComRestResponse> request = new WPComGsonRequest<>(Method.GET,
                 url, null, SiteWPComRestResponse.class,
                 new Listener<SiteWPComRestResponse>() {

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/xmlrpc/XMLRPC.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/xmlrpc/XMLRPC.java
@@ -1,0 +1,17 @@
+package org.wordpress.android.stores.network.xmlrpc;
+
+public enum XMLRPC {
+    GET_OPTIONS("wp.getOptions"),
+    GET_USERS_BLOGS("wp.getUsersBlogs");
+
+    private final String mEndpoint;
+
+    XMLRPC(String endpoint) {
+        mEndpoint = endpoint;
+    }
+
+    @Override
+    public String toString() {
+        return mEndpoint;
+    }
+}

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/xmlrpc/XMLRPCRequest.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/xmlrpc/XMLRPCRequest.java
@@ -32,11 +32,11 @@ public class XMLRPCRequest extends BaseRequest<Object> {
     private static final String PROTOCOL_CONTENT_TYPE = String.format("text/xml; charset=%s", PROTOCOL_CHARSET);
 
     private final Listener mListener;
-    private final String mMethod;
+    private final XMLRPC mMethod;
     private final Object[] mParams;
     private final XmlSerializer mSerializer = Xml.newSerializer();
 
-    public XMLRPCRequest(String url, String method, List<Object> params, Listener listener,
+    public XMLRPCRequest(String url, XMLRPC method, List<Object> params, Listener listener,
                          ErrorListener errorListener) {
         super(Method.POST, url, errorListener);
         mListener = listener;

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/xmlrpc/XMLSerializerUtils.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/xmlrpc/XMLSerializerUtils.java
@@ -20,7 +20,7 @@ public class XMLSerializerUtils {
     private static final String TAG_FAULT_CODE = "faultCode";
     private static final String TAG_FAULT_STRING = "faultString";
 
-    public static StringWriter serialize(XmlSerializer serializer, String method, Object[] params)
+    public static StringWriter serialize(XmlSerializer serializer, XMLRPC method, Object[] params)
             throws IOException {
         StringWriter bodyWriter = new StringWriter();
         serializer.setOutput(bodyWriter);
@@ -28,7 +28,7 @@ public class XMLSerializerUtils {
         serializer.startDocument(null, null);
         serializer.startTag(null, TAG_METHOD_CALL);
         // set method name
-        serializer.startTag(null, TAG_METHOD_NAME).text(method).endTag(null, TAG_METHOD_NAME);
+        serializer.startTag(null, TAG_METHOD_NAME).text(method.toString()).endTag(null, TAG_METHOD_NAME);
         if (params != null && params.length != 0) {
             // set method params
             serializer.startTag(null, TAG_PARAMS);

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -12,6 +12,7 @@ import org.wordpress.android.stores.model.SitesModel;
 import org.wordpress.android.stores.network.UserAgent;
 import org.wordpress.android.stores.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.stores.network.xmlrpc.BaseXMLRPCClient;
+import org.wordpress.android.stores.network.xmlrpc.XMLRPC;
 import org.wordpress.android.stores.network.xmlrpc.XMLRPCRequest;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -33,7 +34,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         params.add(username);
         params.add(password);
         final XMLRPCRequest request = new XMLRPCRequest(
-                xmlrpcUrl, "wp.getUsersBlogs", params,
+                xmlrpcUrl, XMLRPC.GET_USERS_BLOGS, params,
                 new Listener<Object>() {
                     @Override
                     public void onResponse(Object response) {
@@ -77,7 +78,7 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
         params.add(site.getPassword());
         params.add(blogOptionsXMLRPCParameters);
         final XMLRPCRequest request = new XMLRPCRequest(
-                site.getXMLRpcUrl(), "wp.getOptions", params,
+                site.getXMLRpcUrl(), XMLRPC.GET_OPTIONS, params,
                 new Listener<Object>() {
                     @Override
                     public void onResponse(Object response) {


### PR DESCRIPTION
Fixes #16. With XML-RPC and REST API endpoints all collected in enums, we can easily check endpoint coverage, and it's much easier to find how each endpoint is being used in the app.