### PR TITLE
Adding sign out method to delete Account and access token

### DIFF
--- a/WordPressStores/src/main/java/org/wordpress/android/stores/action/AccountAction.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/action/AccountAction.java
@@ -9,4 +9,5 @@ public enum AccountAction implements IAction {
     POST_SETTINGS, // request saving Account Settings remotely
     POSTED_SETTINGS, // response received from Account Settings post
     UPDATE, // update in-memory and persisted Account in AccountStore
+    SIGN_OUT, // delete persisted Account, reset in-memory Account, delete access token
 }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/model/AccountModel.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/model/AccountModel.java
@@ -69,7 +69,7 @@ public class AccountModel implements Identifiable, Payload {
                 StringUtils.equals(getWebAddress(), otherAccount.getWebAddress());
     }
 
-    private void init() {
+    public void init() {
         mUserName = "";
         mUserId = 0;
         mDisplayName = "";

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/AuthError.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/AuthError.java
@@ -8,4 +8,6 @@ public enum AuthError implements Payload {
     INCORRECT_USERNAME_OR_PASSWORD,
     UNAUTHORIZED,
     HTTP_AUTH_ERROR,
+    NEEDS_2FA, // indicates that a two-factor authentication code is required
+    INVALID_OTP, // indicates the provided two-factor authentication code is incorrect
 }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/auth/AppSecrets.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/auth/AppSecrets.java
@@ -3,10 +3,12 @@ package org.wordpress.android.stores.network.rest.wpcom.auth;
 public class AppSecrets {
     private final String mAppId;
     private final String mAppSecret;
+    private final String mRedirectUri;
 
-    public AppSecrets(String appId, String appSecret) {
+    public AppSecrets(String appId, String appSecret, String redirectUri) {
         mAppId = appId;
         mAppSecret = appSecret;
+        mRedirectUri = redirectUri;
     }
 
     public String getAppId() {
@@ -15,5 +17,9 @@ public class AppSecrets {
 
     public String getAppSecret() {
         return mAppSecret;
+    }
+
+    public String getRedirectUri() {
+        return mRedirectUri;
     }
 }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/auth/Authenticator.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/auth/Authenticator.java
@@ -35,6 +35,12 @@ public class Authenticator {
     public static final String BEARER_GRANT_TYPE = "bearer";
     public static final String AUTHORIZATION_CODE_GRANT_TYPE = "authorization_code";
 
+    // Authentication error response keys/descriptions recognized
+    private static final String INVALID_REQUEST_ERROR = "invalid_request";
+    private static final String NEEDS_TWO_STEP_ERROR = "needs_2fa";
+    private static final String INVALID_OTP_ERROR = "invalid_otp";
+    private static final String INVALID_CREDS_ERROR = "Incorrect username or password.";
+
     private final RequestQueue mRequestQueue;
     private AppSecrets mAppSecrets;
 
@@ -69,6 +75,20 @@ public class Authenticator {
 
     public TokenRequest makeRequest(String code, Listener listener, ErrorListener errorListener) {
         return new BearerRequest(mAppSecrets.getAppId(), mAppSecrets.getAppSecret(), code, listener, errorListener);
+    }
+
+    public AuthError extractAuthError(String error, String description) {
+        if (error.equals(INVALID_REQUEST_ERROR)) {
+            if (description.contains(INVALID_CREDS_ERROR)) {
+                return AuthError.INCORRECT_USERNAME_OR_PASSWORD;
+            }
+        } else if (error.equals(NEEDS_TWO_STEP_ERROR)) {
+            return AuthError.NEEDS_2FA;
+        } else if (error.equals(INVALID_OTP_ERROR)) {
+            return AuthError.INVALID_OTP;
+        }
+
+        return AuthError.UNAUTHORIZED;
     }
 
     private static class TokenRequest extends Request<Token> {

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/auth/Authenticator.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/auth/Authenticator.java
@@ -11,6 +11,7 @@ import com.android.volley.toolbox.HttpHeaderParser;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.wordpress.android.stores.network.AuthError;
 
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/auth/Authenticator.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/auth/Authenticator.java
@@ -27,6 +27,7 @@ public class Authenticator {
 
     public static final String CLIENT_ID_PARAM_NAME = "client_id";
     public static final String CLIENT_SECRET_PARAM_NAME = "client_secret";
+    public static final String REDIRECT_URI_PARAM_NAME = "redirect_uri";
     public static final String CODE_PARAM_NAME = "code";
     public static final String GRANT_TYPE_PARAM_NAME = "grant_type";
     public static final String USERNAME_PARAM_NAME = "username";
@@ -59,8 +60,7 @@ public class Authenticator {
 
     public void authenticate(String username, String password, String twoStepCode, boolean shouldSendTwoStepSMS,
                              Listener listener, ErrorListener errorListener) {
-        TokenRequest tokenRequest = new PasswordRequest(mAppSecrets.getAppId(), mAppSecrets.getAppSecret(),
-                username, password, twoStepCode, shouldSendTwoStepSMS, listener, errorListener);
+        TokenRequest tokenRequest = makeRequest(username, password, twoStepCode, shouldSendTwoStepSMS, listener, errorListener);
         mRequestQueue.add(tokenRequest);
     }
 
@@ -70,12 +70,12 @@ public class Authenticator {
 
     public TokenRequest makeRequest(String username, String password, String twoStepCode, boolean shouldSendTwoStepSMS,
                                     Listener listener, ErrorListener errorListener) {
-        return new PasswordRequest(mAppSecrets.getAppId(), mAppSecrets.getAppSecret(), username, password, twoStepCode,
+        return new PasswordRequest(mAppSecrets.getAppId(), mAppSecrets.getAppSecret(), mAppSecrets.getRedirectUri(), username, password, twoStepCode,
                 shouldSendTwoStepSMS, listener, errorListener);
     }
 
     public TokenRequest makeRequest(String code, Listener listener, ErrorListener errorListener) {
-        return new BearerRequest(mAppSecrets.getAppId(), mAppSecrets.getAppSecret(), code, listener, errorListener);
+        return new BearerRequest(mAppSecrets.getAppId(), mAppSecrets.getAppSecret(), mAppSecrets.getRedirectUri(), code, listener, errorListener);
     }
 
     public AuthError extractAuthError(String error, String description) {
@@ -96,11 +96,14 @@ public class Authenticator {
         private final Listener mListener;
         protected Map<String, String> mParams = new HashMap<>();
 
-        TokenRequest(String appId, String appSecret, Listener listener, ErrorListener errorListener) {
+        TokenRequest(String appId, String appSecret, String redirectUri, Listener listener, ErrorListener errorListener) {
             super(Method.POST, TOKEN_ENDPOINT, errorListener);
             mListener = listener;
             mParams.put(CLIENT_ID_PARAM_NAME, appId);
             mParams.put(CLIENT_SECRET_PARAM_NAME, appSecret);
+            if (!TextUtils.isEmpty(redirectUri)) {
+                mParams.put(REDIRECT_URI_PARAM_NAME, redirectUri);
+            }
         }
 
         @Override
@@ -128,9 +131,9 @@ public class Authenticator {
     }
 
     public static class PasswordRequest extends TokenRequest {
-        public PasswordRequest(String appId, String appSecret, String username, String password, String twoStepCode,
+        public PasswordRequest(String appId, String appSecret, String redirectUri, String username, String password, String twoStepCode,
                                boolean shouldSendTwoStepSMS, Listener listener, ErrorListener errorListener) {
-            super(appId, appSecret, listener, errorListener);
+            super(appId, appSecret, redirectUri, listener, errorListener);
             mParams.put(USERNAME_PARAM_NAME, username);
             mParams.put(PASSWORD_PARAM_NAME, password);
             mParams.put(GRANT_TYPE_PARAM_NAME, PASSWORD_GRANT_TYPE);
@@ -139,17 +142,15 @@ public class Authenticator {
                 mParams.put("wpcom_otp", twoStepCode);
             } else {
                 mParams.put("wpcom_supports_2fa", "true");
-                if (shouldSendTwoStepSMS) {
-                    mParams.put("wpcom_resend_otp", "true");
-                }
+                mParams.put("wpcom_resend_otp", String.valueOf(shouldSendTwoStepSMS));
             }
         }
     }
 
     public static class BearerRequest extends TokenRequest {
-        public BearerRequest(String appId, String appSecret, String code, Listener listener,
+        public BearerRequest(String appId, String appSecret, String redirectUri, String code, Listener listener,
                              ErrorListener errorListener) {
-            super(appId, appSecret, listener, errorListener);
+            super(appId, appSecret, redirectUri, listener, errorListener);
             mParams.put(CODE_PARAM_NAME, code);
             mParams.put(GRANT_TYPE_PARAM_NAME, BEARER_GRANT_TYPE);
         }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/store/AccountStore.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/store/AccountStore.java
@@ -121,7 +121,15 @@ public class AccountStore extends Store {
         } else if (actionType == AccountAction.UPDATE) {
             AccountModel accountModel = (AccountModel) action.getPayload();
             update(accountModel, AccountAction.UPDATE);
+        } else if (actionType == AccountAction.SIGN_OUT) {
+            signOut();
         }
+    }
+
+    public void signOut() {
+        AccountSqlUtils.deleteAccount(mAccount);
+        mAccount.init();
+        mAccessToken.set(null);
     }
 
     public AccountModel getAccount() {

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/store/AccountStore.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/store/AccountStore.java
@@ -3,6 +3,7 @@ package org.wordpress.android.stores.store;
 import com.android.volley.VolleyError;
 import com.squareup.otto.Subscribe;
 
+import org.json.JSONObject;
 import org.wordpress.android.stores.Dispatcher;
 import org.wordpress.android.stores.Payload;
 import org.wordpress.android.stores.action.AccountAction;
@@ -17,6 +18,7 @@ import org.wordpress.android.stores.network.rest.wpcom.auth.AccessToken;
 import org.wordpress.android.stores.network.rest.wpcom.auth.Authenticator;
 import org.wordpress.android.stores.network.rest.wpcom.auth.Authenticator.Token;
 import org.wordpress.android.stores.persistence.AccountSqlUtils;
+import org.wordpress.android.stores.utils.WPUrlUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -33,6 +35,8 @@ public class AccountStore extends Store {
         public AuthenticatePayload() {}
         public String username;
         public String password;
+        public String twoStepCode;
+        public boolean shouldSendTwoStepSms;
         public Action nextAction;
     }
 
@@ -87,7 +91,7 @@ public class AccountStore extends Store {
             emitChange(event);
         } else if (actionType == AuthenticationAction.AUTHENTICATE) {
             AuthenticatePayload payload = (AuthenticatePayload) action.getPayload();
-            authenticate(payload.username, payload.password, payload);
+            authenticate(payload);
         } else if (actionType == AccountAction.FETCH) {
             // fetch Account and Account Settings
             mAccountRestClient.fetchAccount();
@@ -167,25 +171,38 @@ public class AccountStore extends Store {
         return account == null ? new AccountModel() : account;
     }
 
-    private void authenticate(String username, String password, final AuthenticatePayload payload) {
-        mAuthenticator.authenticate(username, password, null, false, new Authenticator.Listener() {
-            @Override
-            public void onResponse(Token token) {
-                mAccessToken.set(token.getAccessToken());
-                if (payload.nextAction != null) {
-                    mDispatcher.dispatch(payload.nextAction);
-                }
-                emitChange(new OnAuthenticationChanged());
-            }
-        }, new Authenticator.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError volleyError) {
-                AppLog.e(T.API, "Authentication error");
-                OnAuthenticationChanged event = new OnAuthenticationChanged();
-                event.isError = true;
-                emitChange(event);
-            }
-        });
+    private void authenticate(final AuthenticatePayload payload) {
+        mAuthenticator.authenticate(payload.username, payload.password, payload.twoStepCode,
+                payload.shouldSendTwoStepSms, new Authenticator.Listener() {
+                    @Override
+                    public void onResponse(Token token) {
+                        mAccessToken.set(token.getAccessToken());
+                        if (payload.nextAction != null) {
+                            mDispatcher.dispatch(payload.nextAction);
+                        }
+                        emitChange(new OnAuthenticationChanged());
+                    }
+                }, new Authenticator.ErrorListener() {
+                    @Override
+                    public void onErrorResponse(VolleyError volleyError) {
+                        AppLog.e(T.API, "Authentication error");
+                        emitChange(handleAuthError(volleyError));
+                    }
+                });
+    }
+
+    private OnAuthenticationChanged handleAuthError(VolleyError volleyError) {
+        OnAuthenticationChanged event = new OnAuthenticationChanged();
+        event.isError = true;
+        JSONObject errorJson = WPUrlUtils.volleyErrorToJSON(volleyError);
+
+        if (errorJson != null) {
+            String error = errorJson.optString("error", "");
+            String errorDescription = errorJson.optString("error_description", "");
+            event.authError = mAuthenticator.extractAuthError(error, errorDescription);
+        }
+
+        return event;
     }
 
     private boolean checkError(AccountRestPayload payload, String log) {

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/utils/WPUrlUtils.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/utils/WPUrlUtils.java
@@ -1,7 +1,12 @@
 package org.wordpress.android.stores.utils;
 
+import com.android.volley.VolleyError;
+
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.wordpress.android.util.UrlUtils;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URL;
 
@@ -48,4 +53,28 @@ public class WPUrlUtils {
         return url.getHost().equals("gravatar.com") || url.getHost().endsWith(".gravatar.com");
     }
 
+    /**
+     * Not strictly working with URLs, but this method exists already in WPUtils and will be removed
+     * when that library is imported.
+     */
+    public static JSONObject volleyErrorToJSON(VolleyError volleyError) {
+        if (volleyError == null || volleyError.networkResponse == null || volleyError.networkResponse.data == null
+                || volleyError.networkResponse.headers == null) {
+            return null;
+        }
+
+        String contentType = volleyError.networkResponse.headers.get("Content-Type");
+        if (contentType == null || !contentType.equals("application/json")) {
+            return null;
+        }
+
+        try {
+            String response = new String(volleyError.networkResponse.data, "UTF-8");
+            return new JSONObject(response);
+        } catch (UnsupportedEncodingException e) {
+            return null;
+        } catch (JSONException e) {
+            return null;
+        }
+    }
 }

--- a/example/gradle.properties-example
+++ b/example/gradle.properties-example
@@ -1,3 +1,4 @@
 # We should use test credentials
 wp.OAUTH.APP.ID = wp
 wp.OAUTH.APP.SECRET = wp
+wp.OAUTH.APP.REDIRECT_URI = wp

--- a/example/src/main/java/org/wordpress/android/stores/example/AppSecretsModule.java
+++ b/example/src/main/java/org/wordpress/android/stores/example/AppSecretsModule.java
@@ -9,6 +9,6 @@ import dagger.Provides;
 public class AppSecretsModule {
     @Provides
     public AppSecrets provideAppSecrets() {
-        return new AppSecrets(BuildConfig.OAUTH_APP_ID, BuildConfig.OAUTH_APP_SECRET);
+        return new AppSecrets(BuildConfig.OAUTH_APP_ID, BuildConfig.OAUTH_APP_SECRET, BuildConfig.OAUTH_APP_REDIRECT_URI);
     }
 }

--- a/example/src/main/java/org/wordpress/android/stores/example/SignInDialog.java
+++ b/example/src/main/java/org/wordpress/android/stores/example/SignInDialog.java
@@ -13,23 +13,26 @@ import android.widget.EditText;
 
 public class SignInDialog extends DialogFragment {
     public interface Listener {
-        void onClick(String username, String password, String url);
+        void onClick(String username, String password, String twoStepCode, String url);
     }
 
     private Listener mListener;
     private EditText mUsernameView;
     private EditText mPasswordView;
+    private EditText mTwoStepView;
     private EditText mUrlView;
     private boolean mUrlEnabled;
+    private boolean mTwoStepEnabled;
 
     public void setListener(Listener onClickListener) {
         mListener = onClickListener;
     }
 
-    public static SignInDialog newInstance(Listener onClickListener, boolean enableUrl) {
+    public static SignInDialog newInstance(Listener onClickListener, boolean enableUrl, boolean enableTwoStep) {
         SignInDialog fragment = new SignInDialog();
         fragment.setListener(onClickListener);
         fragment.setUrlEnabled(enableUrl);
+        fragment.setTwoStepVisible(enableTwoStep);
         return fragment;
     }
 
@@ -41,6 +44,10 @@ public class SignInDialog extends DialogFragment {
         mUrlEnabled = urlEnabled;
     }
 
+    public void setTwoStepVisible(boolean visible) {
+        mTwoStepEnabled = visible;
+    }
+
     @Override
     @NonNull
     public Dialog onCreateDialog(Bundle savedInstanceState) {
@@ -49,14 +56,20 @@ public class SignInDialog extends DialogFragment {
         View view = inflater.inflate(R.layout.signin_dialog, null);
         mUsernameView = (EditText) view.findViewById(R.id.username);
         mPasswordView = (EditText) view.findViewById(R.id.password);
+        mTwoStepView = (EditText) view.findViewById(R.id.twostep);
         mUrlView = (EditText) view.findViewById(R.id.url);
         if (!mUrlEnabled) {
             mUrlView.setVisibility(View.GONE);
         }
+        if (!mTwoStepEnabled) {
+            mTwoStepView.setVisibility(View.GONE);
+        }
         builder.setView(view)
                 .setPositiveButton(android.R.string.ok, new OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
-                        mListener.onClick(mUsernameView.getText().toString(), mPasswordView.getText().toString(),
+                        mListener.onClick(mUsernameView.getText().toString(),
+                                mPasswordView.getText().toString(),
+                                mTwoStepView.getText().toString(),
                                 mUrlView.getText().toString());
                     }
                 })

--- a/example/src/main/res/layout/signin_dialog.xml
+++ b/example/src/main/res/layout/signin_dialog.xml
@@ -18,6 +18,13 @@
         android:layout_margin="4dp"
         android:hint="Password"/>
     <EditText
+        android:id="@+id/twostep"
+        android:inputType="text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="4dp"
+        android:hint="Two Step code"/>
+    <EditText
         android:id="@+id/url"
         android:inputType="textUri"
         android:layout_width="match_parent"

--- a/example/src/test/java/org/wordpress/android/stores/account/AccountStoreTest.java
+++ b/example/src/test/java/org/wordpress/android/stores/account/AccountStoreTest.java
@@ -24,11 +24,13 @@ import org.wordpress.android.stores.store.AccountStore;
 
 @RunWith(RobolectricTestRunner.class)
 public class AccountStoreTest {
+    private Context mContext;
+
     @Before
     public void setUp() {
-        Context appContext = RuntimeEnvironment.application.getApplicationContext();
+        mContext = RuntimeEnvironment.application.getApplicationContext();
 
-        WellSqlConfig config = new SingleStoreWellSqlConfigForTests(appContext, AccountModel.class);
+        WellSqlConfig config = new SingleStoreWellSqlConfigForTests(mContext, AccountModel.class);
         WellSql.init(config);
         config.reset();
     }
@@ -67,6 +69,21 @@ public class AccountStoreTest {
         testStore = new AccountStore(new Dispatcher(), getMockRestClient(),
                 getMockAuthenticator(), getMockAccessToken(false));
         Assert.assertTrue(testStore.isSignedIn());
+    }
+
+    @Test
+    public void testSignOut() {
+        AccountModel testAccount = new AccountModel();
+        AccessToken testToken = new AccessToken(mContext);
+        testToken.set("TESTTOKEN");
+        testAccount.setUserId(24);
+        AccountSqlUtils.insertOrUpdateAccount(testAccount);
+        AccountStore testStore = new AccountStore(new Dispatcher(), getMockRestClient(),
+                getMockAuthenticator(), testToken);
+        Assert.assertTrue(testStore.isSignedIn());
+        testStore.signOut();
+        Assert.assertFalse(testStore.isSignedIn());
+        Assert.assertNull(AccountSqlUtils.getAccountByLocalId(testAccount.getId()));
     }
 
     private AccountRestClient getMockRestClient() {


### PR DESCRIPTION
Fixes #25 by providing a method and action to sign out. Signing out deletes the Account from persisted storage, resets the in-memory reference, and deletes the access token.