### PR TITLE
Use Date class instead of a String and fix a bug (AccountResponse contains creation date)

### DIFF
--- a/WordPressStores/src/main/java/org/wordpress/android/stores/model/AccountModel.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/model/AccountModel.java
@@ -8,6 +8,8 @@ import com.yarolegovich.wellsql.core.annotation.Table;
 import org.wordpress.android.stores.Payload;
 import org.wordpress.android.util.StringUtils;
 
+import java.util.Date;
+
 @Table
 public class AccountModel implements Identifiable, Payload {
     @PrimaryKey
@@ -28,7 +30,7 @@ public class AccountModel implements Identifiable, Payload {
     @Column private String mFirstName;
     @Column private String mLastName;
     @Column private String mAboutMe;
-    @Column private String mDate;
+    @Column private Date mDateCreated;
     @Column private String mNewEmail;
     @Column private boolean mPendingEmailChange;
     @Column private String mWebAddress;
@@ -63,7 +65,7 @@ public class AccountModel implements Identifiable, Payload {
                 StringUtils.equals(getFirstName(), otherAccount.getFirstName()) &&
                 StringUtils.equals(getLastName(), otherAccount.getLastName()) &&
                 StringUtils.equals(getAboutMe(), otherAccount.getAboutMe()) &&
-                StringUtils.equals(getDate(), otherAccount.getDate()) &&
+                getDateCreated().equals(otherAccount.getDateCreated()) &&
                 StringUtils.equals(getNewEmail(), otherAccount.getNewEmail()) &&
                 getPendingEmailChange() == otherAccount.getPendingEmailChange() &&
                 StringUtils.equals(getWebAddress(), otherAccount.getWebAddress());
@@ -82,7 +84,7 @@ public class AccountModel implements Identifiable, Payload {
         mFirstName = "";
         mLastName = "";
         mAboutMe = "";
-        mDate = "";
+        mDateCreated = new Date();
         mNewEmail = "";
         mPendingEmailChange = false;
         mWebAddress = "";
@@ -102,6 +104,7 @@ public class AccountModel implements Identifiable, Payload {
         setSiteCount(other.getSiteCount());
         setVisibleSiteCount(other.getVisibleSiteCount());
         setEmail(other.getEmail());
+        setDateCreated(other.getDateCreated());
     }
 
     /**
@@ -114,10 +117,10 @@ public class AccountModel implements Identifiable, Payload {
         setFirstName(other.getFirstName());
         setLastName(other.getLastName());
         setAboutMe(other.getAboutMe());
-        setDate(other.getDate());
         setNewEmail(other.getNewEmail());
         setPendingEmailChange(other.getPendingEmailChange());
         setWebAddress(other.getWebAddress());
+        setDateCreated(other.getDateCreated());
     }
 
     public long getUserId() {
@@ -216,12 +219,12 @@ public class AccountModel implements Identifiable, Payload {
         return mAboutMe;
     }
 
-    public void setDate(String date) {
-        mDate = date;
+    public void setDateCreated(Date dateCreated) {
+        mDateCreated = dateCreated;
     }
 
-    public String getDate() {
-        return mDate;
+    public Date getDateCreated() {
+        return mDateCreated;
     }
 
     public void setNewEmail(String newEmail) {

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/account/AccountResponse.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/account/AccountResponse.java
@@ -18,4 +18,5 @@ public class AccountResponse implements Response {
     public int site_count;
     public int visible_site_count;
     public String email;
+    public String date;
 }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/account/AccountRestClient.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/account/AccountRestClient.java
@@ -17,6 +17,10 @@ import org.wordpress.android.stores.network.rest.wpcom.WPCOMREST;
 import org.wordpress.android.stores.network.rest.wpcom.WPComGsonRequest;
 import org.wordpress.android.stores.network.rest.wpcom.auth.AccessToken;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -79,7 +83,7 @@ public class AccountRestClient extends BaseWPComRestClient {
                 new Listener<AccountSettingsResponse>() {
                     @Override
                     public void onResponse(AccountSettingsResponse response) {
-                        AccountModel settings = responseToAccountSettingsModel(response);
+                        AccountModel settings = settingsResponseToAccountModel(response);
                         AccountRestPayload payload = new AccountRestPayload(settings, null);
                         mDispatcher.dispatch(AccountActionBuilder.newFetchedSettingsAction(payload));
                     }
@@ -109,7 +113,7 @@ public class AccountRestClient extends BaseWPComRestClient {
                 new Listener<AccountSettingsResponse>() {
                     @Override
                     public void onResponse(AccountSettingsResponse response) {
-                        AccountModel settings = responseToAccountSettingsModel(response);
+                        AccountModel settings = settingsResponseToAccountModel(response);
                         AccountRestPayload payload = new AccountRestPayload(settings, null);
                         mDispatcher.dispatch(AccountActionBuilder.newPostedSettingsAction(payload));
                     }
@@ -135,20 +139,34 @@ public class AccountRestClient extends BaseWPComRestClient {
         account.setSiteCount(from.site_count);
         account.setVisibleSiteCount(from.visible_site_count);
         account.setEmail(from.email);
+        if (from.date != null) {
+            account.setDateCreated(iso8601ToJavaDate(from.date));
+        }
         return account;
     }
 
-    private AccountModel responseToAccountSettingsModel(AccountSettingsResponse from) {
-        AccountModel accountSettings = new AccountModel();
-        accountSettings.setUserName(from.user_login);
-        accountSettings.setPrimaryBlogId(from.primary_site_ID);
-        accountSettings.setFirstName(from.first_name);
-        accountSettings.setLastName(from.last_name);
-        accountSettings.setAboutMe(from.description);
-        accountSettings.setDate(from.date);
-        accountSettings.setNewEmail(from.new_user_email);
-        accountSettings.setPendingEmailChange(from.user_email_change_pending);
-        accountSettings.setWebAddress(from.user_URL);
-        return accountSettings;
+    private AccountModel settingsResponseToAccountModel(AccountSettingsResponse from) {
+        AccountModel account = new AccountModel();
+        account.setUserName(from.user_login);
+        account.setPrimaryBlogId(from.primary_site_ID);
+        account.setFirstName(from.first_name);
+        account.setLastName(from.last_name);
+        account.setAboutMe(from.description);
+        account.setNewEmail(from.new_user_email);
+        account.setPendingEmailChange(from.user_email_change_pending);
+        account.setWebAddress(from.user_URL);
+        if (from.date != null) {
+            account.setDateCreated(iso8601ToJavaDate(from.date));
+        }
+        return account;
+    }
+
+    private Date iso8601ToJavaDate(final String strDate) {
+        try {
+            SimpleDateFormat ISO8601Format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US);
+            return ISO8601Format.parse(strDate);
+        } catch (ParseException e) {
+            return new Date();
+        }
     }
 }

--- a/example/src/test/java/org/wordpress/android/stores/account/AccountModelTest.java
+++ b/example/src/test/java/org/wordpress/android/stores/account/AccountModelTest.java
@@ -56,7 +56,7 @@ public class AccountModelTest {
         copyAccount.setFirstName("copyFirstName");
         copyAccount.setLastName("copyLastName");
         copyAccount.setAboutMe("copyAboutMe");
-        copyAccount.setDate("copyDate");
+        copyAccount.setDateCreated("copyDate");
         copyAccount.setNewEmail("copyNewEmail");
         copyAccount.setPendingEmailChange(!testAccount.getPendingEmailChange());
         copyAccount.setWebAddress("copyWebAddress");


### PR DESCRIPTION
fix #31: Use Date class instead of a String and fix a bug (AccountResponse contains creation date)