### PR TITLE
Fix #63: drop `AccountStore.isSignedIn` method

### DIFF
--- a/WordPressStores/src/main/java/org/wordpress/android/stores/store/AccountStore.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/store/AccountStore.java
@@ -321,8 +321,8 @@ public class AccountStore extends Store {
     /**
      * Checks if an Account is currently signed in to WordPress.com or any WordPress.org sites.
      */
-    public boolean isSignedIn() {
-        return hasAccessToken() || mAccount.getVisibleSiteCount() > 0;
+    public boolean isSignedIn(SiteStore siteStore) {
+        return hasAccessToken() || siteStore.hasDotOrgSite();
     }
 
     private void updateToken(UpdateTokenPayload updateTokenPayload) {

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/store/AccountStore.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/store/AccountStore.java
@@ -318,13 +318,6 @@ public class AccountStore extends Store {
         return mAccessToken.get();
     }
 
-    /**
-     * Checks if an Account is currently signed in to WordPress.com or any WordPress.org sites.
-     */
-    public boolean isSignedIn(SiteStore siteStore) {
-        return hasAccessToken() || siteStore.hasDotOrgSite();
-    }
-
     private void updateToken(UpdateTokenPayload updateTokenPayload) {
         mAccessToken.set(updateTokenPayload.token);
     }

--- a/example/src/main/java/org/wordpress/android/stores/example/MainExampleActivity.java
+++ b/example/src/main/java/org/wordpress/android/stores/example/MainExampleActivity.java
@@ -309,7 +309,7 @@ public class MainExampleActivity extends AppCompatActivity {
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onAccountChanged(OnAccountChanged event) {
-        if (!mAccountStore.isSignedIn()) {
+        if (!mAccountStore.isSignedIn(mSiteStore)) {
             prependToLog("Signed Out");
         } else {
             if (event.accountInfosChanged) {

--- a/example/src/main/java/org/wordpress/android/stores/example/MainExampleActivity.java
+++ b/example/src/main/java/org/wordpress/android/stores/example/MainExampleActivity.java
@@ -309,7 +309,7 @@ public class MainExampleActivity extends AppCompatActivity {
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onAccountChanged(OnAccountChanged event) {
-        if (!mAccountStore.isSignedIn(mSiteStore)) {
+        if (!mAccountStore.hasAccessToken()) {
             prependToLog("Signed Out");
         } else {
             if (event.accountInfosChanged) {

--- a/example/src/main/res/layout/activity_example.xml
+++ b/example/src/main/res/layout/activity_example.xml
@@ -66,7 +66,7 @@
                 android:id="@+id/signout"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Sign Out"
+                android:text="Sign Out from WPCOM"
                 />
 
         </LinearLayout>

--- a/example/src/test/java/org/wordpress/android/stores/account/AccountStoreTest.java
+++ b/example/src/test/java/org/wordpress/android/stores/account/AccountStoreTest.java
@@ -66,12 +66,12 @@ public class AccountStoreTest {
         AccountSqlUtils.insertOrUpdateDefaultAccount(testAccount);
         AccountStore testStore = new AccountStore(new Dispatcher(), getMockRestClient(),
                 getMockSelfHostedEndpointFinder(), getMockAuthenticator(), getMockAccessToken(false));
-        Assert.assertFalse(testStore.isSignedIn());
+        Assert.assertFalse(testStore.hasAccessToken());
         testAccount.setVisibleSiteCount(1);
         AccountSqlUtils.insertOrUpdateDefaultAccount(testAccount);
         testStore = new AccountStore(new Dispatcher(), getMockRestClient(), getMockSelfHostedEndpointFinder(),
-                getMockAuthenticator(), getMockAccessToken(false));
-        Assert.assertTrue(testStore.isSignedIn());
+                getMockAuthenticator(), getMockAccessToken(true));
+        Assert.assertTrue(testStore.hasAccessToken());
     }
 
     @Test
@@ -83,12 +83,12 @@ public class AccountStoreTest {
         AccountSqlUtils.insertOrUpdateDefaultAccount(testAccount);
         AccountStore testStore = new AccountStore(new Dispatcher(), getMockRestClient(),
                 getMockSelfHostedEndpointFinder(), getMockAuthenticator(), testToken);
-        Assert.assertTrue(testStore.isSignedIn());
+        Assert.assertTrue(testStore.hasAccessToken());
         // Signout is private (and it should remain private)
         Method privateMethod = AccountStore.class.getDeclaredMethod("signOut");
         privateMethod.setAccessible(true);
         privateMethod.invoke(testStore);
-        Assert.assertFalse(testStore.isSignedIn());
+        Assert.assertFalse(testStore.hasAccessToken());
         Assert.assertNull(AccountSqlUtils.getAccountByLocalId(testAccount.getId()));
     }
 


### PR DESCRIPTION
Fix #63: drop `AccountStore.isSignedIn` method, this should be managed by the app or eventually by an utility method at the library level but not by the AccountStore itself.