### PR TITLE
Fix #41: Add conventions for actions and events

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,36 @@ a WordPress.com OAuth2 ID and secret.
 
 We have some tests connecting to real HTTP servers, URL and credentials are defined in `example/tests.properties`, you must edit it or obtain the real file to run the tests. This is temporary.
 
+## Naming conventions for actions and events
+
+### Actions
+
+Each store should have a corresponding enum defining actions for that store. For example, [SiteStore][4]`'s actions are defined in the [SiteAction][5] enum.
+
+Action naming guide:
+
+    FETCH_X - request data from the server
+    UPDATE_X - local change
+    REMOVE_X - local remove
+    DELETE_X - request deletion on the server
+
+Each action enum should be annotated with `@ActionEnum`, with individual actions receiving an `@Action` annotation with an optional `payloadType` setting (see [SiteAction][5] for an example).
+
+### Events
+
+Events naming guide:
+
+    onXChanged(int rowsAffected) - Keep X singular even if multiple X were changed
+    onXRemoved(int rowsAffected) - Keep X singular even if multiple X were removed
+
 ## Need help to build or hack?
 
-Say hello on our [Slack][4] channel: `#mobile`.
+Say hello on our [Slack][6] channel: `#mobile`.
 
 ## LICENSE
 
 WordPress-Stores-Android is an Open Source project covered by the [GNU General Public License version 2](LICENSE.md).
 
-[4]: https://make.wordpress.org/chat/
+[4]: https://github.com/wordpress-mobile/WordPress-Stores-Android/blob/52ffa86d604f3f2df1b46bc3e9f20f7552ceeea5/WordPressStores/src/main/java/org/wordpress/android/stores/store/SiteStore.java
+[5]: https://github.com/wordpress-mobile/WordPress-Stores-Android/blob/52ffa86d604f3f2df1b46bc3e9f20f7552ceeea5/WordPressStores/src/main/java/org/wordpress/android/stores/action/SiteAction.java
+[6]: https://make.wordpress.org/chat/

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 WordPress-Stores-Android is a networking and persistence library that helps to connect and sync data from a WordPress site (self hosted, or wordpress.com site). It's not ready for prime time yet.
 
-Based on the [Flux](https://facebook.github.io/flux/docs/overview.html) pattern, we're using: [Dagger2](https://google.github.io/dagger/) for dependency injection, [WellSql](https://github.com/yarolegovich/wellsql) for persistence.
+Based on the [Flux][1] pattern, we're using: [Dagger2][2] for dependency injection, [WellSql][3] for persistence.
 
 ## Building the library
 
-The [gradle build system][2] will fetch all dependencies and generate
+The gradle build system will fetch all dependencies and generate
 files you need to build the project. You first need to generate the
 local.properties (replace YOUR_SDK_DIR with your actual android SDK directory)
 file and create the gradle.properties file. The easiest way is to copy
@@ -59,6 +59,9 @@ Say hello on our [Slack][6] channel: `#mobile`.
 
 WordPress-Stores-Android is an Open Source project covered by the [GNU General Public License version 2](LICENSE.md).
 
+[1]: https://facebook.github.io/flux/docs/overview.html
+[2]: https://google.github.io/dagger/
+[3]: https://github.com/yarolegovich/wellsql
 [4]: https://github.com/wordpress-mobile/WordPress-Stores-Android/blob/52ffa86d604f3f2df1b46bc3e9f20f7552ceeea5/WordPressStores/src/main/java/org/wordpress/android/stores/store/SiteStore.java
 [5]: https://github.com/wordpress-mobile/WordPress-Stores-Android/blob/52ffa86d604f3f2df1b46bc3e9f20f7552ceeea5/WordPressStores/src/main/java/org/wordpress/android/stores/action/SiteAction.java
 [6]: https://make.wordpress.org/chat/

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/action/AccountAction.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/action/AccountAction.java
@@ -14,8 +14,6 @@ import org.wordpress.android.stores.store.AccountStore.UpdateTokenPayload;
 @ActionEnum
 public enum AccountAction implements IAction {
     @Action
-    FETCH,                  // request fetch of both Account and Account Settings
-    @Action
     FETCH_ACCOUNT,          // request fetch of Account information
     @Action(payloadType = AccountRestPayload.class)
     FETCHED_ACCOUNT,        // response received from Account fetch request

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/action/AccountAction.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/action/AccountAction.java
@@ -26,7 +26,7 @@ public enum AccountAction implements IAction {
     @Action(payloadType = AccountPostSettingsResponsePayload.class)
     POSTED_SETTINGS,        // response received from Account Settings post
     @Action(payloadType = AccountModel.class)
-    UPDATE,                 // update in-memory and persisted Account in AccountStore
+    UPDATE_ACCOUNT,                 // update in-memory and persisted Account in AccountStore
     @Action(payloadType = UpdateTokenPayload.class)
     UPDATE_ACCESS_TOKEN,    // update in-memory and persisted Access Token
     @Action

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/store/AccountStore.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/store/AccountStore.java
@@ -225,10 +225,6 @@ public class AccountStore extends Store {
                 discoverySucceeded.wpRestEndpoint = payload.wpRestEndpoint;
                 emitChange(discoverySucceeded);
             }
-        } else if (actionType == AccountAction.FETCH) {
-            // fetch Account and Account Settings
-            mAccountRestClient.fetchAccount();
-            mAccountRestClient.fetchAccountSettings();
         } else if (actionType == AccountAction.FETCH_ACCOUNT) {
             // fetch only Account
             mAccountRestClient.fetchAccount();

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/store/AccountStore.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/store/AccountStore.java
@@ -259,9 +259,9 @@ public class AccountStore extends Store {
                 }
             }
             // TODO: error management
-        } else if (actionType == AccountAction.UPDATE) {
+        } else if (actionType == AccountAction.UPDATE_ACCOUNT) {
             AccountModel accountModel = (AccountModel) action.getPayload();
-            updateDefaultAccount(accountModel, AccountAction.UPDATE);
+            updateDefaultAccount(accountModel, AccountAction.UPDATE_ACCOUNT);
         } else if (actionType == AccountAction.UPDATE_ACCESS_TOKEN) {
             UpdateTokenPayload updateTokenPayload = (UpdateTokenPayload) action.getPayload();
             updateToken(updateTokenPayload);

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/store/SiteStore.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/store/SiteStore.java
@@ -65,10 +65,10 @@ public class SiteStore extends Store {
         }
     }
 
-    public class OnSitesRemoved extends OnChanged {
+    public class OnSiteRemoved extends OnChanged {
         public int mRowsAffected;
 
-        public OnSitesRemoved(int rowsAffected) {
+        public OnSiteRemoved(int rowsAffected) {
             mRowsAffected = rowsAffected;
         }
     }
@@ -458,14 +458,14 @@ public class SiteStore extends Store {
             // TODO: This should be captured by 'QuickPressShortcutsStore' so it can handle deleting any QP shortcuts
             // TODO: Probably, we can inject QuickPressShortcutsStore into SiteStore and act on it directly
             // See WordPressDB.deleteQuickPressShortcutsForLocalTableBlogId(Context ctx, int blogId)
-            emitChange(new OnSitesRemoved(rowsAffected));
+            emitChange(new OnSiteRemoved(rowsAffected));
         } else if (actionType == SiteAction.REMOVE_WPCOM_SITES) {
             // Logging out of WP.com. Drop all WP.com sites, and all Jetpack sites that were pulled over the WP.com
             // REST API only (they don't have a .org site id)
             List<SiteModel> wpcomSites = SiteSqlUtils.getAllWPComSites();
             int rowsAffected = removeSites(wpcomSites);
             // TODO: Same as above, this needs to be captured and handled by QuickPressShortcutsStore
-            emitChange(new OnSitesRemoved(rowsAffected));
+            emitChange(new OnSiteRemoved(rowsAffected));
         } else if (actionType == SiteAction.SHOW_SITES) {
             toggleSitesVisibility((SitesModel) action.getPayload(), true);
         } else if (actionType == SiteAction.HIDE_SITES) {

--- a/example/src/androidTest/java/org/wordpress/android/stores/release/ReleaseStack_AccountTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/stores/release/ReleaseStack_AccountTest.java
@@ -65,7 +65,8 @@ public class ReleaseStack_AccountTest extends ReleaseStack_Base {
             authenticate(BuildConfig.TEST_WPCOM_USERNAME_TEST1, BuildConfig.TEST_WPCOM_PASSWORD_TEST1);
         }
         mExpectedAction = ACCOUNT_TEST_ACTIONS.FETCHED;
-        mDispatcher.dispatch(AccountActionBuilder.newFetchAction());
+        mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
+        mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
         mCountDownLatch = new CountDownLatch(2);
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
     }

--- a/example/src/androidTest/java/org/wordpress/android/stores/release/ReleaseStack_DiscoveryTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/stores/release/ReleaseStack_DiscoveryTest.java
@@ -313,7 +313,7 @@ public class ReleaseStack_DiscoveryTest extends ReleaseStack_Base {
     }
 
     @Subscribe
-    public void OnSitesRemoved(SiteStore.OnSitesRemoved event) {
+    public void OnSiteRemoved(SiteStore.OnSiteRemoved event) {
         AppLog.i(T.TESTS, "site count " + mSiteStore.getSitesCount());
         assertEquals(false, mSiteStore.hasSite());
         assertEquals(false, mSiteStore.hasDotOrgSite());

--- a/example/src/androidTest/java/org/wordpress/android/stores/release/ReleaseStack_SiteTest.java
+++ b/example/src/androidTest/java/org/wordpress/android/stores/release/ReleaseStack_SiteTest.java
@@ -197,7 +197,7 @@ public class ReleaseStack_SiteTest extends ReleaseStack_Base {
     }
 
     @Subscribe
-    public void OnSitesRemoved(SiteStore.OnSitesRemoved event) {
+    public void OnSiteRemoved(SiteStore.OnSiteRemoved event) {
         AppLog.e(T.TESTS, "site count " + mSiteStore.getSitesCount());
         assertEquals(false, mSiteStore.hasSite());
         assertEquals(false, mSiteStore.hasDotOrgSite());

--- a/example/src/androidTest/java/org/wordpress/android/stores/release/ReleaseStack_SiteTestWPCOM.java
+++ b/example/src/androidTest/java/org/wordpress/android/stores/release/ReleaseStack_SiteTestWPCOM.java
@@ -66,7 +66,7 @@ public class ReleaseStack_SiteTestWPCOM extends ReleaseStack_Base {
 
         assertEquals(true, mCountDownLatch.await(TestUtils.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS));
 
-        // Clear WP.com sites, and wait for OnSitesRemoved event
+        // Clear WP.com sites, and wait for OnSiteRemoved event
         mCountDownLatch = new CountDownLatch(1);
         mExpectedEvent = TEST_EVENTS.SITE_REMOVED;
         mExpectedRowsAffected = mSiteStore.getSitesCount();
@@ -91,7 +91,7 @@ public class ReleaseStack_SiteTestWPCOM extends ReleaseStack_Base {
     }
 
     @Subscribe
-    public void OnSitesRemoved(SiteStore.OnSitesRemoved event) {
+    public void OnSiteRemoved(SiteStore.OnSiteRemoved event) {
         AppLog.e(T.TESTS, "site count " + mSiteStore.getSitesCount());
         assertEquals(mExpectedRowsAffected, event.mRowsAffected);
         assertEquals(false, mSiteStore.hasSite());

--- a/example/src/main/java/org/wordpress/android/stores/example/MainExampleActivity.java
+++ b/example/src/main/java/org/wordpress/android/stores/example/MainExampleActivity.java
@@ -83,7 +83,8 @@ public class MainExampleActivity extends AppCompatActivity {
         mAccountInfos.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                mDispatcher.dispatch(AccountActionBuilder.newFetchAction());
+                mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
+                mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
             }
         });
         mUpdateFirstSite = (Button) findViewById(R.id.update_first_site);

--- a/example/src/main/java/org/wordpress/android/stores/example/MainExampleActivity.java
+++ b/example/src/main/java/org/wordpress/android/stores/example/MainExampleActivity.java
@@ -36,7 +36,7 @@ import org.wordpress.android.stores.store.SiteStore;
 import org.wordpress.android.stores.store.SiteStore.NewSitePayload;
 import org.wordpress.android.stores.store.SiteStore.OnNewSiteCreated;
 import org.wordpress.android.stores.store.SiteStore.OnSiteChanged;
-import org.wordpress.android.stores.store.SiteStore.OnSitesRemoved;
+import org.wordpress.android.stores.store.SiteStore.OnSiteRemoved;
 import org.wordpress.android.stores.store.SiteStore.RefreshSitesXMLRPCPayload;
 import org.wordpress.android.stores.store.SiteStore.SiteVisibility;
 import org.wordpress.android.util.AppLog;
@@ -389,7 +389,7 @@ public class MainExampleActivity extends AppCompatActivity {
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onSitesRemoved(OnSitesRemoved event) {
+    public void onSiteRemoved(OnSiteRemoved event) {
         mUpdateFirstSite.setEnabled(mSiteStore.hasSite());
     }
 }


### PR DESCRIPTION
Fixes #41.

* Added guide to README for naming actions and events
* Dropped `AccountAction.FETCH`, replacing its usage with separate calls to `FETCH_ACCOUNT` and `FETCH_SETTINGS`
* Renamed `AccountAction.UPDATE` to `UPDATE_ACCOUNT`
* Renamed `OnSitesRemoved` to `OnSiteRemoved`

cc @maxme 