### PR TITLE
Fix #68: Add timezone to SiteModel and update the value from REST or XMLRPC request

### DIFF
--- a/WordPressStores/src/main/java/org/wordpress/android/stores/model/SiteModel.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/model/SiteModel.java
@@ -23,6 +23,8 @@ public class SiteModel implements Identifiable, Payload {
     @Column private boolean mIsWPCom;
     @Column private boolean mIsAdmin;
     @Column private boolean mIsFeaturedImageSupported;
+    @Column private String mTimezone;
+
 
     // Self hosted specifics
     // The siteId for .org sites. Jetpack sites will also have a mSiteId, which is their id on .COM
@@ -176,5 +178,13 @@ public class SiteModel implements Identifiable, Payload {
 
     public void setIsVideoPressSupported(boolean videoPressSupported) {
         mIsVideoPressSupported = videoPressSupported;
+    }
+
+    public String getTimezone() {
+        return mTimezone;
+    }
+
+    public void setTimezone(String timezone) {
+        mTimezone = timezone;
     }
 }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/site/SiteRestClient.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/site/SiteRestClient.java
@@ -147,6 +147,7 @@ public class SiteRestClient extends BaseWPComRestClient {
             site.setIsFeaturedImageSupported(from.options.featured_images_enabled);
             site.setIsVideoPressSupported(from.options.videopress_enabled);
             site.setAdminUrl(from.options.admin_url);
+            site.setTimezone(from.options.timezone);
         }
         site.setIsWPCom(true);
         return site;

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -14,6 +14,7 @@ public class SiteWPComRestResponse implements Payload, Response {
         public boolean videopress_enabled;
         public boolean featured_images_enabled;
         public String admin_url;
+        public String timezone;
     }
 
     public int ID;

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/xmlrpc/site/SiteXMLRPCClient.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/xmlrpc/site/SiteXMLRPCClient.java
@@ -134,13 +134,14 @@ public class SiteXMLRPCClient extends BaseXMLRPCClient {
     }
 
     private SiteModel updateSiteFromOptions(Object response, SiteModel oldModel) {
-        // TODO: plenty of other options to read here from requested blogOptionsXMLRPCParameters
         Map<?, ?> blogOptions = (Map<?, ?>) response;
         oldModel.setName(getOption(blogOptions, "blog_title", String.class));
         // TODO: set a canonical URL here
         oldModel.setUrl(getOption(blogOptions, "home_url", String.class));
         oldModel.setSoftwareVersion(getOption(blogOptions, "software_version", String.class));
-        oldModel.setIsFeaturedImageSupported(getOption(blogOptions, "post_thumbnail", Boolean.class));
+        Boolean post_thumbnail = getOption(blogOptions, "post_thumbnail", Boolean.class);
+        oldModel.setIsFeaturedImageSupported((post_thumbnail != null) && post_thumbnail);
+        oldModel.setTimezone(getOption(blogOptions, "time_zone", String.class));
         long dotComIdForJetpack = Long.valueOf(getOption(blogOptions, "jetpack_client_id", String.class));
         oldModel.setSiteId(dotComIdForJetpack);
         if (dotComIdForJetpack != 0) {


### PR DESCRIPTION
Fix #68: I'm not sure why, but that value is always the empty string on .com REST