### PR TITLE
Fix #70: add plan id/shortname to sitemodel and fetch it from site(s) update

### DIFF
--- a/WordPressStores/src/main/java/org/wordpress/android/stores/model/SiteModel.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/model/SiteModel.java
@@ -36,6 +36,8 @@ public class SiteModel implements Identifiable, Payload {
     @Column private boolean mIsJetpack;
     @Column private boolean mIsVisible;
     @Column private boolean mIsVideoPressSupported;
+    @Column private long mPlanId;
+    @Column private String mPlanShortName;
 
     @Override
     public int getId() {
@@ -176,5 +178,21 @@ public class SiteModel implements Identifiable, Payload {
 
     public void setIsVideoPressSupported(boolean videoPressSupported) {
         mIsVideoPressSupported = videoPressSupported;
+    }
+
+    public String getPlanShortName() {
+        return mPlanShortName;
+    }
+
+    public void setPlanShortName(String planShortName) {
+        mPlanShortName = planShortName;
+    }
+
+    public long getPlanId() {
+        return mPlanId;
+    }
+
+    public void setPlanId(long planId) {
+        mPlanId = planId;
     }
 }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/site/SiteRestClient.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/site/SiteRestClient.java
@@ -148,6 +148,10 @@ public class SiteRestClient extends BaseWPComRestClient {
             site.setIsVideoPressSupported(from.options.videopress_enabled);
             site.setAdminUrl(from.options.admin_url);
         }
+        if (from.plan != null) {
+            site.setPlanId(from.plan.product_id);
+            site.setPlanShortName(from.plan.product_name_short);
+        }
         site.setIsWPCom(true);
         return site;
     }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -16,6 +16,11 @@ public class SiteWPComRestResponse implements Payload, Response {
         public String admin_url;
     }
 
+    public class Plan {
+        public long product_id;
+        public String product_name_short;
+    }
+
     public int ID;
     public String URL;
     public String name;
@@ -23,6 +28,7 @@ public class SiteWPComRestResponse implements Payload, Response {
     public boolean jetpack;
     public boolean visible;
     public Options options;
+    public Plan plan;
 }
 
 


### PR DESCRIPTION
Fix #70: add plan id/shortname to sitemodel and fetch it from site(s) update