### PR TITLE
Add site capabilities to wpcom sites

### DIFF
--- a/WordPressStores/src/main/java/org/wordpress/android/stores/model/SiteModel.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/model/SiteModel.java
@@ -37,6 +37,26 @@ public class SiteModel implements Identifiable, Payload {
     @Column private boolean mIsVisible;
     @Column private boolean mIsVideoPressSupported;
 
+    // WPCom capabilities
+    @Column private boolean mIsCapabilityEditPages;
+    @Column private boolean mIsCapabilityEditPosts;
+    @Column private boolean mIsCapabilityEditOthersPosts;
+    @Column private boolean mIsCapabilityEditOthersPages;
+    @Column private boolean mIsCapabilityDeletePosts;
+    @Column private boolean mIsCapabilityDeleteOthersPosts;
+    @Column private boolean mIsCapabilityEditThemeOptions;
+    @Column private boolean mIsCapabilityEditUsers;
+    @Column private boolean mIsCapabilityListUsers;
+    @Column private boolean mIsCapabilityManageCategories;
+    @Column private boolean mIsCapabilityManageOptions;
+    @Column private boolean mIsCapabilityActivateWordads;
+    @Column private boolean mIsCapabilityPromoteUsers;
+    @Column private boolean mIsCapabilityPublishPosts;
+    @Column private boolean mIsCapabilityUploadFiles;
+    @Column private boolean mIsCapabilityDeleteUser;
+    @Column private boolean mIsCapabilityRemoveUsers;
+    @Column private boolean mIsCapabilityViewStats;
+
     @Override
     public int getId() {
         return mId;
@@ -176,5 +196,149 @@ public class SiteModel implements Identifiable, Payload {
 
     public void setIsVideoPressSupported(boolean videoPressSupported) {
         mIsVideoPressSupported = videoPressSupported;
+    }
+
+    public boolean isCapabilityEditPages() {
+        return mIsCapabilityEditPages;
+    }
+
+    public void setIsCapabilityEditPages(boolean capabilityEditPages) {
+        mIsCapabilityEditPages = capabilityEditPages;
+    }
+
+    public boolean isCapabilityEditPosts() {
+        return mIsCapabilityEditPosts;
+    }
+
+    public void setIsCapabilityEditPosts(boolean capabilityEditPosts) {
+        mIsCapabilityEditPosts = capabilityEditPosts;
+    }
+
+    public boolean isCapabilityEditOthersPosts() {
+        return mIsCapabilityEditOthersPosts;
+    }
+
+    public void setIsCapabilityEditOthersPosts(boolean capabilityEditOthersPosts) {
+        mIsCapabilityEditOthersPosts = capabilityEditOthersPosts;
+    }
+
+    public boolean isCapabilityEditOthersPages() {
+        return mIsCapabilityEditOthersPages;
+    }
+
+    public void setIsCapabilityEditOthersPages(boolean capabilityEditOthersPages) {
+        mIsCapabilityEditOthersPages = capabilityEditOthersPages;
+    }
+
+    public boolean isCapabilityDeletePosts() {
+        return mIsCapabilityDeletePosts;
+    }
+
+    public void setIsCapabilityDeletePosts(boolean capabilityDeletePosts) {
+        mIsCapabilityDeletePosts = capabilityDeletePosts;
+    }
+
+    public boolean isCapabilityDeleteOthersPosts() {
+        return mIsCapabilityDeleteOthersPosts;
+    }
+
+    public void setIsCapabilityDeleteOthersPosts(boolean capabilityDeleteOthersPosts) {
+        mIsCapabilityDeleteOthersPosts = capabilityDeleteOthersPosts;
+    }
+
+    public boolean isCapabilityEditThemeOptions() {
+        return mIsCapabilityEditThemeOptions;
+    }
+
+    public void setIsCapabilityEditThemeOptions(boolean capabilityEditThemeOptions) {
+        mIsCapabilityEditThemeOptions = capabilityEditThemeOptions;
+    }
+
+    public boolean isCapabilityEditUsers() {
+        return mIsCapabilityEditUsers;
+    }
+
+    public void setIsCapabilityEditUsers(boolean capabilityEditUsers) {
+        mIsCapabilityEditUsers = capabilityEditUsers;
+    }
+
+    public boolean isCapabilityListUsers() {
+        return mIsCapabilityListUsers;
+    }
+
+    public void setIsCapabilityListUsers(boolean capabilityListUsers) {
+        mIsCapabilityListUsers = capabilityListUsers;
+    }
+
+    public boolean isCapabilityManageCategories() {
+        return mIsCapabilityManageCategories;
+    }
+
+    public void setIsCapabilityManageCategories(boolean capabilityManageCategories) {
+        mIsCapabilityManageCategories = capabilityManageCategories;
+    }
+
+    public boolean isCapabilityManageOptions() {
+        return mIsCapabilityManageOptions;
+    }
+
+    public void setIsCapabilityManageOptions(boolean capabilityManageOptions) {
+        mIsCapabilityManageOptions = capabilityManageOptions;
+    }
+
+    public boolean isCapabilityActivateWordads() {
+        return mIsCapabilityActivateWordads;
+    }
+
+    public void setIsCapabilityActivateWordads(boolean capabilityActivateWordads) {
+        mIsCapabilityActivateWordads = capabilityActivateWordads;
+    }
+
+    public boolean isCapabilityPromoteUsers() {
+        return mIsCapabilityPromoteUsers;
+    }
+
+    public void setIsCapabilityPromoteUsers(boolean capabilityPromoteUsers) {
+        mIsCapabilityPromoteUsers = capabilityPromoteUsers;
+    }
+
+    public boolean isCapabilityPublishPosts() {
+        return mIsCapabilityPublishPosts;
+    }
+
+    public void setIsCapabilityPublishPosts(boolean capabilityPublishPosts) {
+        mIsCapabilityPublishPosts = capabilityPublishPosts;
+    }
+
+    public boolean isCapabilityUploadFiles() {
+        return mIsCapabilityUploadFiles;
+    }
+
+    public void setIsCapabilityUploadFiles(boolean capabilityUploadFiles) {
+        mIsCapabilityUploadFiles = capabilityUploadFiles;
+    }
+
+    public boolean isCapabilityDeleteUser() {
+        return mIsCapabilityDeleteUser;
+    }
+
+    public void setIsCapabilityDeleteUser(boolean capabilityDeleteUser) {
+        mIsCapabilityDeleteUser = capabilityDeleteUser;
+    }
+
+    public boolean isCapabilityRemoveUsers() {
+        return mIsCapabilityRemoveUsers;
+    }
+
+    public void setIsCapabilityRemoveUsers(boolean capabilityRemoveUsers) {
+        mIsCapabilityRemoveUsers = capabilityRemoveUsers;
+    }
+
+    public boolean isCapabilityViewStats() {
+        return mIsCapabilityViewStats;
+    }
+
+    public void setIsCapabilityViewStats(boolean capabilityViewStats) {
+        mIsCapabilityViewStats = capabilityViewStats;
     }
 }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/model/SiteModel.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/model/SiteModel.java
@@ -44,24 +44,24 @@ public class SiteModel implements Identifiable, Payload, Serializable {
     @Column private String mPlanShortName;
 
     // WPCom capabilities
-    @Column private boolean mIsCapabilityEditPages;
-    @Column private boolean mIsCapabilityEditPosts;
-    @Column private boolean mIsCapabilityEditOthersPosts;
-    @Column private boolean mIsCapabilityEditOthersPages;
-    @Column private boolean mIsCapabilityDeletePosts;
-    @Column private boolean mIsCapabilityDeleteOthersPosts;
-    @Column private boolean mIsCapabilityEditThemeOptions;
-    @Column private boolean mIsCapabilityEditUsers;
-    @Column private boolean mIsCapabilityListUsers;
-    @Column private boolean mIsCapabilityManageCategories;
-    @Column private boolean mIsCapabilityManageOptions;
-    @Column private boolean mIsCapabilityActivateWordads;
-    @Column private boolean mIsCapabilityPromoteUsers;
-    @Column private boolean mIsCapabilityPublishPosts;
-    @Column private boolean mIsCapabilityUploadFiles;
-    @Column private boolean mIsCapabilityDeleteUser;
-    @Column private boolean mIsCapabilityRemoveUsers;
-    @Column private boolean mIsCapabilityViewStats;
+    @Column private boolean mHasCapabilityEditPages;
+    @Column private boolean mHasCapabilityEditPosts;
+    @Column private boolean mHasCapabilityEditOthersPosts;
+    @Column private boolean mHasCapabilityEditOthersPages;
+    @Column private boolean mHasCapabilityDeletePosts;
+    @Column private boolean mHasCapabilityDeleteOthersPosts;
+    @Column private boolean mHasCapabilityEditThemeOptions;
+    @Column private boolean mHasCapabilityEditUsers;
+    @Column private boolean mHasCapabilityListUsers;
+    @Column private boolean mHasCapabilityManageCategories;
+    @Column private boolean mHasCapabilityManageOptions;
+    @Column private boolean mHasCapabilityActivateWordads;
+    @Column private boolean mHasCapabilityPromoteUsers;
+    @Column private boolean mHasCapabilityPublishPosts;
+    @Column private boolean mHasCapabilityUploadFiles;
+    @Column private boolean mHasCapabilityDeleteUser;
+    @Column private boolean mHasCapabilityRemoveUsers;
+    @Column private boolean mHasCapabilityViewStats;
 
     @Override
     public int getId() {
@@ -204,148 +204,148 @@ public class SiteModel implements Identifiable, Payload, Serializable {
         mIsVideoPressSupported = videoPressSupported;
     }
 
-    public boolean isCapabilityEditPages() {
-        return mIsCapabilityEditPages;
+    public boolean getHasCapabilityEditPages() {
+        return mHasCapabilityEditPages;
     }
 
-    public void setIsCapabilityEditPages(boolean capabilityEditPages) {
-        mIsCapabilityEditPages = capabilityEditPages;
+    public void setHasCapabilityEditPages(boolean hasCapabilityEditPages) {
+        mHasCapabilityEditPages = hasCapabilityEditPages;
     }
 
-    public boolean isCapabilityEditPosts() {
-        return mIsCapabilityEditPosts;
+    public boolean getHasCapabilityEditPosts() {
+        return mHasCapabilityEditPosts;
     }
 
-    public void setIsCapabilityEditPosts(boolean capabilityEditPosts) {
-        mIsCapabilityEditPosts = capabilityEditPosts;
+    public void setHasCapabilityEditPosts(boolean capabilityEditPosts) {
+        mHasCapabilityEditPosts = capabilityEditPosts;
     }
 
-    public boolean isCapabilityEditOthersPosts() {
-        return mIsCapabilityEditOthersPosts;
+    public boolean getHasCapabilityEditOthersPosts() {
+        return mHasCapabilityEditOthersPosts;
     }
 
-    public void setIsCapabilityEditOthersPosts(boolean capabilityEditOthersPosts) {
-        mIsCapabilityEditOthersPosts = capabilityEditOthersPosts;
+    public void setHasCapabilityEditOthersPosts(boolean capabilityEditOthersPosts) {
+        mHasCapabilityEditOthersPosts = capabilityEditOthersPosts;
     }
 
-    public boolean isCapabilityEditOthersPages() {
-        return mIsCapabilityEditOthersPages;
+    public boolean getHasCapabilityEditOthersPages() {
+        return mHasCapabilityEditOthersPages;
     }
 
-    public void setIsCapabilityEditOthersPages(boolean capabilityEditOthersPages) {
-        mIsCapabilityEditOthersPages = capabilityEditOthersPages;
+    public void setHasCapabilityEditOthersPages(boolean capabilityEditOthersPages) {
+        mHasCapabilityEditOthersPages = capabilityEditOthersPages;
     }
 
-    public boolean isCapabilityDeletePosts() {
-        return mIsCapabilityDeletePosts;
+    public boolean getHasCapabilityDeletePosts() {
+        return mHasCapabilityDeletePosts;
     }
 
-    public void setIsCapabilityDeletePosts(boolean capabilityDeletePosts) {
-        mIsCapabilityDeletePosts = capabilityDeletePosts;
+    public void setHasCapabilityDeletePosts(boolean capabilityDeletePosts) {
+        mHasCapabilityDeletePosts = capabilityDeletePosts;
     }
 
-    public boolean isCapabilityDeleteOthersPosts() {
-        return mIsCapabilityDeleteOthersPosts;
+    public boolean getHasCapabilityDeleteOthersPosts() {
+        return mHasCapabilityDeleteOthersPosts;
     }
 
-    public void setIsCapabilityDeleteOthersPosts(boolean capabilityDeleteOthersPosts) {
-        mIsCapabilityDeleteOthersPosts = capabilityDeleteOthersPosts;
+    public void setHasCapabilityDeleteOthersPosts(boolean capabilityDeleteOthersPosts) {
+        mHasCapabilityDeleteOthersPosts = capabilityDeleteOthersPosts;
     }
 
-    public boolean isCapabilityEditThemeOptions() {
-        return mIsCapabilityEditThemeOptions;
+    public boolean getHasCapabilityEditThemeOptions() {
+        return mHasCapabilityEditThemeOptions;
     }
 
-    public void setIsCapabilityEditThemeOptions(boolean capabilityEditThemeOptions) {
-        mIsCapabilityEditThemeOptions = capabilityEditThemeOptions;
+    public void setHasCapabilityEditThemeOptions(boolean capabilityEditThemeOptions) {
+        mHasCapabilityEditThemeOptions = capabilityEditThemeOptions;
     }
 
-    public boolean isCapabilityEditUsers() {
-        return mIsCapabilityEditUsers;
+    public boolean getHasCapabilityEditUsers() {
+        return mHasCapabilityEditUsers;
     }
 
-    public void setIsCapabilityEditUsers(boolean capabilityEditUsers) {
-        mIsCapabilityEditUsers = capabilityEditUsers;
+    public void setHasCapabilityEditUsers(boolean capabilityEditUsers) {
+        mHasCapabilityEditUsers = capabilityEditUsers;
     }
 
-    public boolean isCapabilityListUsers() {
-        return mIsCapabilityListUsers;
+    public boolean getHasCapabilityListUsers() {
+        return mHasCapabilityListUsers;
     }
 
-    public void setIsCapabilityListUsers(boolean capabilityListUsers) {
-        mIsCapabilityListUsers = capabilityListUsers;
+    public void setHasCapabilityListUsers(boolean capabilityListUsers) {
+        mHasCapabilityListUsers = capabilityListUsers;
     }
 
-    public boolean isCapabilityManageCategories() {
-        return mIsCapabilityManageCategories;
+    public boolean getHasCapabilityManageCategories() {
+        return mHasCapabilityManageCategories;
     }
 
-    public void setIsCapabilityManageCategories(boolean capabilityManageCategories) {
-        mIsCapabilityManageCategories = capabilityManageCategories;
+    public void setHasCapabilityManageCategories(boolean capabilityManageCategories) {
+        mHasCapabilityManageCategories = capabilityManageCategories;
     }
 
-    public boolean isCapabilityManageOptions() {
-        return mIsCapabilityManageOptions;
+    public boolean getHasCapabilityManageOptions() {
+        return mHasCapabilityManageOptions;
     }
 
-    public void setIsCapabilityManageOptions(boolean capabilityManageOptions) {
-        mIsCapabilityManageOptions = capabilityManageOptions;
+    public void setHasCapabilityManageOptions(boolean capabilityManageOptions) {
+        mHasCapabilityManageOptions = capabilityManageOptions;
     }
 
-    public boolean isCapabilityActivateWordads() {
-        return mIsCapabilityActivateWordads;
+    public boolean getHasCapabilityActivateWordads() {
+        return mHasCapabilityActivateWordads;
     }
 
-    public void setIsCapabilityActivateWordads(boolean capabilityActivateWordads) {
-        mIsCapabilityActivateWordads = capabilityActivateWordads;
+    public void setHasCapabilityActivateWordads(boolean capabilityActivateWordads) {
+        mHasCapabilityActivateWordads = capabilityActivateWordads;
     }
 
-    public boolean isCapabilityPromoteUsers() {
-        return mIsCapabilityPromoteUsers;
+    public boolean getHasCapabilityPromoteUsers() {
+        return mHasCapabilityPromoteUsers;
     }
 
-    public void setIsCapabilityPromoteUsers(boolean capabilityPromoteUsers) {
-        mIsCapabilityPromoteUsers = capabilityPromoteUsers;
+    public void setHasCapabilityPromoteUsers(boolean capabilityPromoteUsers) {
+        mHasCapabilityPromoteUsers = capabilityPromoteUsers;
     }
 
-    public boolean isCapabilityPublishPosts() {
-        return mIsCapabilityPublishPosts;
+    public boolean getHasCapabilityPublishPosts() {
+        return mHasCapabilityPublishPosts;
     }
 
-    public void setIsCapabilityPublishPosts(boolean capabilityPublishPosts) {
-        mIsCapabilityPublishPosts = capabilityPublishPosts;
+    public void setHasCapabilityPublishPosts(boolean capabilityPublishPosts) {
+        mHasCapabilityPublishPosts = capabilityPublishPosts;
     }
 
-    public boolean isCapabilityUploadFiles() {
-        return mIsCapabilityUploadFiles;
+    public boolean getHasCapabilityUploadFiles() {
+        return mHasCapabilityUploadFiles;
     }
 
-    public void setIsCapabilityUploadFiles(boolean capabilityUploadFiles) {
-        mIsCapabilityUploadFiles = capabilityUploadFiles;
+    public void setHasCapabilityUploadFiles(boolean capabilityUploadFiles) {
+        mHasCapabilityUploadFiles = capabilityUploadFiles;
     }
 
-    public boolean isCapabilityDeleteUser() {
-        return mIsCapabilityDeleteUser;
+    public boolean getHasCapabilityDeleteUser() {
+        return mHasCapabilityDeleteUser;
     }
 
-    public void setIsCapabilityDeleteUser(boolean capabilityDeleteUser) {
-        mIsCapabilityDeleteUser = capabilityDeleteUser;
+    public void setHasCapabilityDeleteUser(boolean capabilityDeleteUser) {
+        mHasCapabilityDeleteUser = capabilityDeleteUser;
     }
 
-    public boolean isCapabilityRemoveUsers() {
-        return mIsCapabilityRemoveUsers;
+    public boolean getHasCapabilityRemoveUsers() {
+        return mHasCapabilityRemoveUsers;
     }
 
-    public void setIsCapabilityRemoveUsers(boolean capabilityRemoveUsers) {
-        mIsCapabilityRemoveUsers = capabilityRemoveUsers;
+    public void setHasCapabilityRemoveUsers(boolean capabilityRemoveUsers) {
+        mHasCapabilityRemoveUsers = capabilityRemoveUsers;
     }
 
-    public boolean isCapabilityViewStats() {
-        return mIsCapabilityViewStats;
+    public boolean getHasCapabilityViewStats() {
+        return mHasCapabilityViewStats;
     }
 
-    public void setIsCapabilityViewStats(boolean capabilityViewStats) {
-        mIsCapabilityViewStats = capabilityViewStats;
+    public void setHasCapabilityViewStats(boolean capabilityViewStats) {
+        mHasCapabilityViewStats = capabilityViewStats;
     }
 
     public String getTimezone() {

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/site/SiteRestClient.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/site/SiteRestClient.java
@@ -148,6 +148,26 @@ public class SiteRestClient extends BaseWPComRestClient {
             site.setIsVideoPressSupported(from.options.videopress_enabled);
             site.setAdminUrl(from.options.admin_url);
         }
+        if (from.capabilities != null) {
+            site.setIsCapabilityEditPages(from.capabilities.edit_pages);
+            site.setIsCapabilityEditPosts(from.capabilities.edit_posts);
+            site.setIsCapabilityEditOthersPosts(from.capabilities.edit_others_posts);
+            site.setIsCapabilityEditOthersPages(from.capabilities.edit_others_pages);
+            site.setIsCapabilityDeletePosts(from.capabilities.delete_posts);
+            site.setIsCapabilityDeleteOthersPosts(from.capabilities.delete_others_posts);
+            site.setIsCapabilityEditThemeOptions(from.capabilities.edit_theme_options);
+            site.setIsCapabilityEditUsers(from.capabilities.edit_users);
+            site.setIsCapabilityListUsers(from.capabilities.list_users);
+            site.setIsCapabilityManageCategories(from.capabilities.manage_categories);
+            site.setIsCapabilityManageOptions(from.capabilities.manage_options);
+            site.setIsCapabilityActivateWordads(from.capabilities.activate_wordads);
+            site.setIsCapabilityPromoteUsers(from.capabilities.promote_users);
+            site.setIsCapabilityPublishPosts(from.capabilities.publish_posts);
+            site.setIsCapabilityUploadFiles(from.capabilities.upload_files);
+            site.setIsCapabilityDeleteUser(from.capabilities.delete_user);
+            site.setIsCapabilityRemoveUsers(from.capabilities.remove_users);
+            site.setIsCapabilityViewStats(from.capabilities.view_stats);
+        }
         site.setIsWPCom(true);
         return site;
     }

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/site/SiteRestClient.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/site/SiteRestClient.java
@@ -154,24 +154,24 @@ public class SiteRestClient extends BaseWPComRestClient {
             site.setPlanShortName(from.plan.product_name_short);
         }
         if (from.capabilities != null) {
-            site.setIsCapabilityEditPages(from.capabilities.edit_pages);
-            site.setIsCapabilityEditPosts(from.capabilities.edit_posts);
-            site.setIsCapabilityEditOthersPosts(from.capabilities.edit_others_posts);
-            site.setIsCapabilityEditOthersPages(from.capabilities.edit_others_pages);
-            site.setIsCapabilityDeletePosts(from.capabilities.delete_posts);
-            site.setIsCapabilityDeleteOthersPosts(from.capabilities.delete_others_posts);
-            site.setIsCapabilityEditThemeOptions(from.capabilities.edit_theme_options);
-            site.setIsCapabilityEditUsers(from.capabilities.edit_users);
-            site.setIsCapabilityListUsers(from.capabilities.list_users);
-            site.setIsCapabilityManageCategories(from.capabilities.manage_categories);
-            site.setIsCapabilityManageOptions(from.capabilities.manage_options);
-            site.setIsCapabilityActivateWordads(from.capabilities.activate_wordads);
-            site.setIsCapabilityPromoteUsers(from.capabilities.promote_users);
-            site.setIsCapabilityPublishPosts(from.capabilities.publish_posts);
-            site.setIsCapabilityUploadFiles(from.capabilities.upload_files);
-            site.setIsCapabilityDeleteUser(from.capabilities.delete_user);
-            site.setIsCapabilityRemoveUsers(from.capabilities.remove_users);
-            site.setIsCapabilityViewStats(from.capabilities.view_stats);
+            site.setHasCapabilityEditPages(from.capabilities.edit_pages);
+            site.setHasCapabilityEditPosts(from.capabilities.edit_posts);
+            site.setHasCapabilityEditOthersPosts(from.capabilities.edit_others_posts);
+            site.setHasCapabilityEditOthersPages(from.capabilities.edit_others_pages);
+            site.setHasCapabilityDeletePosts(from.capabilities.delete_posts);
+            site.setHasCapabilityDeleteOthersPosts(from.capabilities.delete_others_posts);
+            site.setHasCapabilityEditThemeOptions(from.capabilities.edit_theme_options);
+            site.setHasCapabilityEditUsers(from.capabilities.edit_users);
+            site.setHasCapabilityListUsers(from.capabilities.list_users);
+            site.setHasCapabilityManageCategories(from.capabilities.manage_categories);
+            site.setHasCapabilityManageOptions(from.capabilities.manage_options);
+            site.setHasCapabilityActivateWordads(from.capabilities.activate_wordads);
+            site.setHasCapabilityPromoteUsers(from.capabilities.promote_users);
+            site.setHasCapabilityPublishPosts(from.capabilities.publish_posts);
+            site.setHasCapabilityUploadFiles(from.capabilities.upload_files);
+            site.setHasCapabilityDeleteUser(from.capabilities.delete_user);
+            site.setHasCapabilityRemoveUsers(from.capabilities.remove_users);
+            site.setHasCapabilityViewStats(from.capabilities.view_stats);
         }
         site.setIsWPCom(true);
         return site;

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/site/SiteWPComRestResponse.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/network/rest/wpcom/site/SiteWPComRestResponse.java
@@ -16,6 +16,27 @@ public class SiteWPComRestResponse implements Payload, Response {
         public String admin_url;
     }
 
+    public class Capabilities {
+        public boolean edit_pages;
+        public boolean edit_posts;
+        public boolean edit_others_posts;
+        public boolean edit_others_pages;
+        public boolean delete_posts;
+        public boolean delete_others_posts;
+        public boolean edit_theme_options;
+        public boolean edit_users;
+        public boolean list_users;
+        public boolean manage_categories;
+        public boolean manage_options;
+        public boolean activate_wordads;
+        public boolean promote_users;
+        public boolean publish_posts;
+        public boolean upload_files;
+        public boolean delete_user;
+        public boolean remove_users;
+        public boolean view_stats;
+    }
+
     public int ID;
     public String URL;
     public String name;
@@ -23,6 +44,7 @@ public class SiteWPComRestResponse implements Payload, Response {
     public boolean jetpack;
     public boolean visible;
     public Options options;
+    public Capabilities capabilities;
 }
 
 


### PR DESCRIPTION
I was hesitant to add all capabilities flat like this, it's ugly. Introducing another model and a 1-to-1 binding will make things more complicated for one only purpose: clean the site model.