### PR TITLE
Fix #93: Use ThreadMode.ASYNC for onAction methods

### DIFF
--- a/WordPressStores/src/main/java/org/wordpress/android/stores/store/AccountStore.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/store/AccountStore.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import com.android.volley.VolleyError;
 
 import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.stores.Dispatcher;
 import org.wordpress.android.stores.Payload;
 import org.wordpress.android.stores.action.AccountAction;
@@ -195,7 +196,7 @@ public class AccountStore extends Store {
         AppLog.d(T.API, "AccountStore onRegister");
     }
 
-    @Subscribe
+    @Subscribe(threadMode = ThreadMode.ASYNC)
     @Override
     public void onAction(Action action) {
         IAction actionType = action.getType();

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/store/SiteStore.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/store/SiteStore.java
@@ -8,6 +8,7 @@ import com.yarolegovich.wellsql.WellSql;
 import com.yarolegovich.wellsql.mapper.SelectMapper;
 
 import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.stores.Dispatcher;
 import org.wordpress.android.stores.Payload;
 import org.wordpress.android.stores.action.SiteAction;
@@ -428,7 +429,7 @@ public class SiteStore extends Store {
         }
     }
 
-    @Subscribe
+    @Subscribe(threadMode = ThreadMode.ASYNC)
     @Override
     public void onAction(Action action) {
         IAction actionType = action.getType();

--- a/WordPressStores/src/main/java/org/wordpress/android/stores/store/Store.java
+++ b/WordPressStores/src/main/java/org/wordpress/android/stores/store/Store.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.stores.store;
 
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.stores.Dispatcher;
 import org.wordpress.android.stores.annotations.action.Action;
 
@@ -11,6 +13,10 @@ public abstract class Store {
         mDispatcher.register(this);
     }
     public class OnChanged {}
+
+    /**
+     * onAction should {@link Subscribe} with ASYNC {@link ThreadMode}.
+     */
     public abstract void onAction(Action action);
     public abstract void onRegister();
 


### PR DESCRIPTION
This ensures that all action handling is performed on worker threads.

cc @maxme